### PR TITLE
change the header_info in HDU features

### DIFF
--- a/corgisim/__in__.py
+++ b/corgisim/__in__.py
@@ -1,0 +1,15 @@
+from .convolution import *
+from .data import *
+from .instrument import *
+from .observation import *
+from .scene import *
+
+
+import warnings
+warnings.filterwarnings("ignore")
+
+__all__ = ['convolution', 'data', 'instrument', 'observation', 'scene',]
+
+__version__ = '0.1'
+__spec__ = __name__
+__package__ = __path__[0]

--- a/corgisim/__in__.py
+++ b/corgisim/__in__.py
@@ -3,10 +3,13 @@ from .data import *
 from .instrument import *
 from .observation import *
 from .scene import *
+import os
 
 
 import warnings
 warnings.filterwarnings("ignore")
+
+
 
 __all__ = ['convolution', 'data', 'instrument', 'observation', 'scene',]
 

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -89,7 +89,17 @@ class CorgiOptics():
 
         sim_scene = scene.SimulatedScene(input_scene)
         
-        sim_scene.host_star_image = create_hdu(image)
+        header_info = {'wvl_c':np.median(self.lambda_m),
+                    's_teff':input_scene.host_star_Teff,
+                    's_rad':input_scene.host_star_Rs,
+                    's_dis':input_scene.host_star_Dist,
+                    }
+        keys_to_include_in_header = ['cor_type', 'use_errors','polaxis','final_sampling_lam0', 'use_dm1','use_dm2','use_fpm',
+                            'use_lyot_stop','use_field_stop','npsf']  # Specify keys to include
+        subset = {key: self.proper_keywords[key] for key in keys_to_include_in_header if key in self.proper_keywords}
+        header_info.update(subset)
+
+        sim_scene.host_star_image = create_hdu(image,header_info =header_info)
 
         return sim_scene
 
@@ -251,25 +261,27 @@ def create_hdu(data, header_info=None):
         - hdu (fits.PrimaryHDU): Astropy HDU object containing the data and header_info
         """
         # Create the Primary HDU with the data
-        primary_hdu = fits.PrimaryHDU()
+        ##primary_hdu = fits.PrimaryHDU()
         # Create an Image HDU with data
-        image_hdu = fits.ImageHDU(data)
+        ##image_hdu = fits.ImageHDU(data)
         # Combine them into an HDUList
-        hdul = fits.HDUList([primary_hdu, image_hdu])
+        ##hdul = fits.HDUList([primary_hdu, image_hdu])
 
         ####read default header and pass into the hdu
-        file_path = pkg_resources.resource_filename("corgisim.data", "data/CGI_0000000000000000014_20221004T2359351_L1_.fits")
-        with fits.open(file_path) as hdul_default:
-            primary_header = hdul_default[0].header
-            image_header = hdul_default[1].header
+        ##file_path = pkg_resources.resource_filename("corgisim.data", "data/CGI_0000000000000000014_20221004T2359351_L1_.fits")
+        ##with fits.open(file_path) as hdul_default:
+        ##    primary_header = hdul_default[0].header
+        #3    image_header = hdul_default[1].header
 
-        hdul[0].header = primary_header  # Primary HDU header
-        hdul[1].header = image_header    # Image HDU header
+        ##hdul[0].header = primary_header  # Primary HDU header
+        ##hdul[1].header = image_header    # Image HDU header
+        hdul = fits.PrimaryHDU(data)
 
         if header_info is not None:
         # Add customerized header info to the header
-            for key, value in header_info():
-                hdul[1].header[key] = value
+            #print(header_info)
+            for key, value in header_info.items():
+                hdul.header[key] = value
             
         return hdul
 

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1,5 +1,8 @@
 
-
+import proper
+import numpy as np
+from astropy.io import fits
+import roman_preflight_proper
 
 class CorgiOptics():
     '''
@@ -14,7 +17,7 @@ class CorgiOptics():
 
     '''
 
-    def __init__(self, proper_keywords):
+    def __init__(self, lambda_m, proper_keywords, diam = 2.363114):
         '''
 
         Initialize the class a keyword dictionary that defines the setup of cgisim/PROPER 
@@ -22,10 +25,17 @@ class CorgiOptics():
 
 
         Initialize the class with two dictionaries: 
+        - lambda_m (float or array): the wavelength for the simulation
         - proper_keywords: A dictionary with the keywords that are used to set up the proper model
         '''
+        self.lambda_m = lambda_m ## wavelength in nm
+        self.diam = diam  ## diameter of Roman primary meter, default is 2.36114 meter
+        self.area = (self.diam/2)**2 * np.pi ### collecting area in unit of m^2
+        self.proper_keywords = proper_keywords  # Store the keywords for later use
 
-    def get_psf(self, scene, on_the_fly=False, oversample = 1, return_oversample = False):
+        print("CorgiOptics initialized with proper keywords.")
+
+    def get_psf(self, scene, sim_scene, on_the_fly=False, oversample = 1, return_oversample = False):
         '''
         
         Function that provides an on-axis PSF for the current configuration of CGI.
@@ -36,8 +46,8 @@ class CorgiOptics():
         PSF should be either generated on the fly, or picked from a pregenerated library (e.g. OS11 
         or something cached locally). 
 
-        TODO: Figure out the default output units. Current candidate is photoelectrons/s. 
-        TODO: If the input is a scene.Simulation_Scene instead, then just pull the Scene from the attribute 
+        #Todo Figure out the default output units. Current candidate is photoelectrons/s. 
+        #Todo: If the input is a scene.Simulation_Scene instead, then just pull the Scene from the attribute 
                 and put the output of this function into the host_star_image attribute.
 
         Arguments: 
@@ -51,6 +61,33 @@ class CorgiOptics():
                                         HDU that contains a noiseless on-axis PSF.
 
         '''
+        ### calculate the star flux at the given wavelenghts in unit of W/m^2/nm
+        host_star_flux = fstar(lam=self.lambda_m, teff=scene.host_star_Teff, rs=scene.host_star_Rs, d=scene.host_star_Dist)
+       
+        ### convert star flux W/m^2/nm to photons/m^2/nm
+        host_star_photons = power2photon(self.lambda_m, host_star_flux)
+        
+        ### calculate the photons collected by the telescope in unit of photons/s/nm
+        collected_photons = host_star_photons * self.area 
+        
+        nlam = len(self.lambda_m)
+        if  nlam ==1:
+            ####simulate monochramtic image, output image is in the unit of photons/s/nm
+            (fields, sampling) = proper.prop_run('roman_preflight', self.lambda_m[0]/1e3,self.proper_keywords['npsf'], QUIET=self.proper_keywords['if_quiet'],PRINT_INTENSITY=self.proper_keywords['if_print_intensity'],PASSVALUE=self.proper_keywords)
+            image = np.abs(fields)**2  * collected_photons 
+
+        if  nlam > 1:
+            ####simulate broadband image, output image is in the unit of photons/s 
+            dl = np.append(np.diff(self.lambda_m),np.diff(self.lambda_m)[0])
+            collected_photons_l =  collected_photons * dl ###photons/s in each wavelength interval
+            
+            (fields, sampling) = proper.prop_run_multi('roman_preflight', self.lambda_m/1e3, self.proper_keywords['npsf'], QUIET=self.proper_keywords['if_quiet'],PRINT_INTENSITY=self.proper_keywords['if_print_intensity'],PASSVALUE=self.proper_keywords)
+            images = np.abs(fields)**2
+            image = np.sum(images *  collected_photons_l[:, np.newaxis, np.newaxis],0)
+        
+        sim_scene.host_star_image =  image
+
+        return 
 
 
     def simulate_2D_scene(self, scene, on_the_fly=False, oversample = 1, return_oversample = False):
@@ -79,6 +116,7 @@ class CorgiOptics():
         corgisim.scene.Simulated_Scene: A scene object with the background_scene attribute populated with an astropy
                                         HDU that contains the simulated scene.
         '''
+        pass
 
 
     def inject_point_sources(self, scene, on_the_fly=False, oversample = 1, return_oversample = False):
@@ -106,6 +144,7 @@ class CorgiOptics():
         Returns: 
         A 2D numpy array that contains the scene with the injected point sources. 
         '''
+        pass
     
 class CorgiDetector(): 
     
@@ -116,6 +155,7 @@ class CorgiDetector():
         Arguments: 
         emccd_keywords: A dictionary with the keywords that are used to set up the emccd model
         '''
+        pass
     
 
     def generate_detector_image(self, simulated_scene):
@@ -130,6 +170,7 @@ class CorgiDetector():
         Returns:
         A corgisim.scene.Scene object that contains the detector image in the 
         '''
+        pass
 
     def place_scene_on_detector(self, scene):
         '''
@@ -143,3 +184,52 @@ class CorgiDetector():
 
         Likely an intermediate step that typical users won't touch. 
         '''
+        pass
+
+
+
+def fstar(lam=None, teff=None, rs=None, d=None):
+    '''
+    Function that calculates the stellar blackbody flux in units of W/m²/nm.
+
+    Arguments: 
+        lam (float or array): wavelength (nm)
+        teff (float): host star effective temperature (K)
+        rs (float): stellar radius (solar radii)
+        d (float): distance to star (pc)
+       
+
+    Returns:
+        flux (float or array): stellar blackbody flux at the given wavelengths (W/m²/nm).
+    '''
+
+    rsun = 6.958e8       # solar radius (m)
+    ds = 3.08567e16      # parsec (m)
+    
+    liambda = 1.e-9*lam  # wavelength (m)
+    c1 = 3.7417715e-16   # 2*pi*h*c*c (kg m**4 / s**3)
+    c2 = 1.4387769e-2    # h*c/k (m K)
+    pow =c2/liambda/teff
+
+    Fs = c1/( (liambda**5.)*(np.exp(pow)-1.0) )*1e-9
+
+    return Fs*(rs*rsun/d/ds)**2
+
+def power2photon(wvl, power):
+    '''
+    Function that coverts spetral power from W/M^2/nm to phonto/M^2/nm
+
+    Arguments: 
+        wvl (float or array): wavelength (nm)
+        power (float): stellar blackbody flux in W/m²/nm
+
+    Returns:
+        photocounts (float or array): in photo/s/m²/nm.
+    '''
+    
+    h = 6.626e-34  ##unit: J*s
+    c = 3e8 * 1e9  ## unit: nm/s
+    fre = c / wvl
+    photonum=power / h / fre
+
+    return photonum

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -280,8 +280,13 @@ def create_hdu(data, header_info=None):
         if header_info is not None:
         # Add customerized header info to the header
             #print(header_info)
+            hdul.header['COMMENT'] = "This FITS file contains simulated data."
+            hdul.header['COMMENT'] = "Header includes stellar properties and other simulation details."
+
             for key, value in header_info.items():
-                hdul.header[key] = value
+                comment = key+' : '+str(value)
+                hdul.header.add_comment(comment)
+                #hdul.header[key] = value
             
         return hdul
 

--- a/corgisim/observation.py
+++ b/corgisim/observation.py
@@ -11,5 +11,6 @@ def generate_observation_sequence(scene, cgi_optics, cgi_detector, exp_time, n_f
     Arguments: 
     scene
     '''
+    pass
 
 

--- a/corgisim/scene.py
+++ b/corgisim/scene.py
@@ -1,4 +1,5 @@
-
+import proper
+import numpy as np
 
 class Scene():
     ''' 
@@ -10,18 +11,91 @@ class Scene():
         - Input with North-Up East-Left orientation.
 
     Arguments: 
-        host_star_properties: A dictionary that contains information about the host star, such as: 
+        host_star_properties (dict): A dictionary that contains information about the host star, such as: 
             brightness, spectral type, ra?, dec?, etc. 
-        point_sources_info: A list of dictionaries that contain information about the point sources, such as:
+        point_sources_info (list): A list of dictionaries that contain information about the point sources, such as:
             brightness, location, spectra?, etc.
-        background_scene: An astropy HDU that contains a background scene as data and a header full of relevant information, such as: 
+        background_scene (HDUList): An astropy HDU that contains a background scene as data and a header full of relevant information, such as: 
             pixel_scale, etc. 
     '''
     def __init__(self, host_star_properties=None, point_source_info=None, twoD_scene_hdu=None):
-        self.host_star_dict = host_star_properties
-        self.point_source_list = point_source_info
-        self.twoD_scene = twoD_scene_hdu
+        self._host_star_Dist = host_star_properties['Dist']  ## host star distance (pc)
+        self._host_star_Teff = host_star_properties['Teff']  ## host star effective temperature (K)
+        self._host_star_Rs = host_star_properties['Rs']  ## host star radius (solar radii)
+        self._point_source_list = point_source_info
+        self._twoD_scene = twoD_scene_hdu
 
+            
+    @property
+    def host_star_Dist(self):
+        """
+        A Method returns host star distance in pc.
+        Returns:
+            Distance (float): in parsecs (pc).
+        """
+        return self._host_star_Dist
+
+                
+    @host_star_Dist.setter
+    def host_star_Dist(self, value):
+        """
+        Setter method to validate and set the host star distance.
+        Args:
+            value (float): The host star distance in parsecs (pc). Must be greater than 0.
+        Raises:
+            ValueError: If `value` is not greater than 0.
+        """
+        if value <= 0:
+            raise ValueError("Distance must be larger than 0!")
+        self._host_star_Dist = float(value)
+        
+    @property
+    def host_star_Teff(self):
+        """
+        A Method returns host star temperature in K.
+        Returns:
+            Temperature (float): in K.
+        """
+        return self._host_star_Teff
+
+                
+    @host_star_Teff.setter
+    def host_star_Teff(self, value):
+        """
+        Setter method to validate and set the host star temperature.
+        Args:
+            value (float): The host star temperature in K. Must be greater than 3000K and less than 12000K.
+        Raises:
+            ValueError: If `value` is less than 3000K or greater than 12000K.
+        """
+        if (value < 3000) or (value > 12000):
+            raise ValueError("Host star temperature is out of range (3000-12000K)!")
+        self._host_star_Teff = float(value)
+
+    @property
+    def host_star_Rs(self):
+        """
+        A Method returns host star radius in solar Radii.
+        Returns:
+            Rs (float): in solar Radii.
+        """
+        return self._host_star_Rs
+
+                
+    @host_star_Rs.setter
+    def host_star_Rs(self, value):
+        """
+        Setter method to validate and set the host star radius.
+        Args:
+            value (float): The host star radius in solar radii. Must be greater than 0.1 solar radii  and less than 10 solar radii.
+        Raises:
+            ValueError: If `value` is less than 0.1 solar radii or greater than 10 solar radii.
+        """
+        if (value < 0.1) or (value > 10):
+            raise ValueError("Host star radius is out of range (0.1-10 solar radii)!")
+        self._host_star_Rs = float(value)
+
+    
 
 
 class SimulatedScene(): 
@@ -30,18 +104,46 @@ class SimulatedScene():
 
     Arguments: 
         input_scene: A corgisim.scene.Scene object that contains the information scene to be simulated.
+
     '''
     def __init__(self, input_scene):
 
         self.input_scene = input_scene
+
 
         #The following three attributes will hold astropy HDUs with the simulated images.
         self.host_star_image = None
         self.point_source_image = None
         self.twoD_image = None
 
+
         #This will be basically the sum of the above three images at the right location on the detector
         self.total_image = None
+
+    def create_hdu(self, data, header_info):
+        """
+        Create an Astropy HDU for the PSF with metadata.
+
+        Parameters:
+        - data (numpy.ndarray): 2D array representing the PSF.
+        - header_info (dict): Dictionary of metadata to include in the header.
+
+        Returns:
+        - hdu (fits.PrimaryHDU): Astropy HDU object containing the data and header_info
+        """
+        # Create the Primary HDU with the data
+        hdu = fits.PrimaryHDU(data)
+        
+        # Add metadata to the header
+        for key, value in header_info():
+            hdu.header[key] = value
+
+        self.hdu = hdu
+        
+        return 
+
+        
+
 
 
 
@@ -57,3 +159,6 @@ def combine_simulated_scenes_list(scene_list):
         corgisim.scene.Simulated_Scene: A scene object with the host_star_image, point_source_image, and background_scene attributes
                                         populated with the sum of the input scenes.
     '''
+    pass
+
+

--- a/corgisim/scene.py
+++ b/corgisim/scene.py
@@ -119,32 +119,7 @@ class SimulatedScene():
 
         #This will be basically the sum of the above three images at the right location on the detector
         self.total_image = None
-
-    def create_hdu(self, data, header_info):
-        """
-        Create an Astropy HDU for the PSF with metadata.
-
-        Parameters:
-        - data (numpy.ndarray): 2D array representing the PSF.
-        - header_info (dict): Dictionary of metadata to include in the header.
-
-        Returns:
-        - hdu (fits.PrimaryHDU): Astropy HDU object containing the data and header_info
-        """
-        # Create the Primary HDU with the data
-        hdu = fits.PrimaryHDU(data)
         
-        # Add metadata to the header
-        for key, value in header_info():
-            hdu.header[key] = value
-
-        self.hdu = hdu
-        
-        return 
-
-        
-
-
 
 
 def combine_simulated_scenes_list(scene_list):

--- a/corgisim/test/test_on_axis_star.py
+++ b/corgisim/test/test_on_axis_star.py
@@ -56,7 +56,7 @@ def run_sim():
     image = sim_scene.host_star_image.data
 
     print('Final_intensity_get:', np.sum(image, dtype = np.float64))
-    #print(sim_scene.host_star_image[1].header)
+    #print(sim_scene.host_star_image.header)
 
     fig = plt.figure()
     plt.imshow(image)

--- a/corgisim/test/test_on_axis_star.py
+++ b/corgisim/test/test_on_axis_star.py
@@ -53,13 +53,13 @@ def run_sim():
     optics = instrument.CorgiOptics(lam_array, proper_keywords=proper_keywords)
     sim_scene = optics.get_psf(base_scene)
 
-    image = sim_scene.host_star_image[1].data
+    image = sim_scene.host_star_image.data
 
     print('Final_intensity_get:', np.sum(image, dtype = np.float64))
     #print(sim_scene.host_star_image[1].header)
 
     fig = plt.figure()
-    plt.imshow(sim_scene.host_star_image[1].data)
+    plt.imshow(image)
     plt.colorbar()
     plt.show()
 

--- a/corgisim/test/test_on_axis_star.py
+++ b/corgisim/test/test_on_axis_star.py
@@ -1,0 +1,77 @@
+from corgisim import scene
+from corgisim import instrument
+from astropy.io import fits
+import matplotlib.pyplot as plt
+import numpy as np
+import proper
+import roman_preflight_proper
+
+#######################
+### Set up a scene. ###
+#######################
+
+def run_sim():
+    print('testrun')
+    
+    
+    #Define the host star properties
+    #host_star_properties = {'v_mag': 1, 'spectral_type': 'G2V', 'ra': 0, 'dec': 0}
+    host_star_properties = {'Teff': 5770, 'Dist':1, 'Rs':1}
+
+    #Create a Scene object that holds all this information
+    base_scene = scene.Scene(host_star_properties)
+    #sim_scene = scene.SimulatedScene(base_scene)
+
+    ####setup the wavelength for the simulation, nlam=1 for monochromatic image, nlam>1 for broadband image
+    lam0 = 575  # unit nm
+    #nlam = 7
+    nlam = 1
+    
+    if nlam > 1:
+        ####simulate broadband image
+        bandwidth = 0.1 
+        minlam = lam0 * (1 - bandwidth/2)
+        maxlam = lam0 * (1 + bandwidth/2)
+        lam_array = np.linspace( minlam, maxlam, nlam )  ### array of wavelength in nm
+
+    if nlam ==1:
+        ####simulate monochramtic image
+        lam_array = np.array([lam0])
+
+
+    cases = ['3e-8']       
+    rootname = 'hlc_ni_' + cases[0]
+    dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
+    dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
+
+    npsf = 256
+    final_sampling = 0.1
+    proper_keywords ={'cor_type':'hlc', 'use_errors':2, 'polaxis':10, 'final_sampling_lam0':final_sampling,\
+                       'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':0, 'use_lyot_stop':0,  'use_field_stop':0,\
+                       'npsf':npsf, 'if_quiet':0, 'if_print_intensity':1 }
+
+    optics = instrument.CorgiOptics(lam_array, proper_keywords=proper_keywords)
+    sim_scene = optics.get_psf(base_scene)
+
+    image = sim_scene.host_star_image[1].data
+
+    print('Final_intensity_get:', np.sum(image, dtype = np.float64))
+    #print(sim_scene.host_star_image[1].header)
+
+    fig = plt.figure()
+    plt.imshow(sim_scene.host_star_image[1].data)
+    plt.colorbar()
+    plt.show()
+
+
+    exit()
+
+    
+
+if __name__ == '__main__':
+    run_sim()
+
+
+
+
+

--- a/examples/example_on_axis_star.py
+++ b/examples/example_on_axis_star.py
@@ -19,7 +19,7 @@ def run_sim():
 
     #Create a Scene object that holds all this information
     base_scene = scene.Scene(host_star_properties)
-    sim_scene = scene.SimulatedScene(base_scene)
+    #sim_scene = scene.SimulatedScene(base_scene)
 
     ####setup the wavelength for the simulation, nlam=1 for monochromatic image, nlam>1 for broadband image
     lam0 = 575  # unit nm
@@ -50,7 +50,7 @@ def run_sim():
                        'npsf':npsf, 'if_quiet':0, 'if_print_intensity':1 }
 
     optics = instrument.CorgiOptics(lam_array, proper_keywords=proper_keywords)
-    optics.get_psf(base_scene, sim_scene)
+    sim_scene = optics.get_psf(base_scene)
 
     print('Final_intensity_get:', np.sum(sim_scene.host_star_image, dtype = np.float64))
 

--- a/examples/example_on_axis_star.py
+++ b/examples/example_on_axis_star.py
@@ -53,10 +53,10 @@ def run_sim():
     sim_scene = optics.get_psf(base_scene)
 
     #print('Final_intensity_get:', np.sum(sim_scene.host_star_image, dtype = np.float64))
-    print(sim_scene.host_star_image[1].header)
+    print(sim_scene.host_star_image.header)
 
     fig = plt.figure()
-    plt.imshow(sim_scene.host_star_image[1].data)
+    plt.imshow(sim_scene.host_star_image.data)
     plt.colorbar()
     plt.show()
 

--- a/examples/example_on_axis_star.py
+++ b/examples/example_on_axis_star.py
@@ -1,45 +1,100 @@
 from corgisim import scene
 from corgisim import instrument
 from astropy.io import fits
+import matplotlib.pyplot as plt
+import numpy as np
+import proper
+import roman_preflight_proper
 
 #######################
 ### Set up a scene. ###
 #######################
 
-####add to test
+def run_sim():
+    print('testrun')
+    
+    #Define the host star properties
+    #host_star_properties = {'v_mag': 1, 'spectral_type': 'G2V', 'ra': 0, 'dec': 0}
+    host_star_properties = {'Teff': 5770, 'Dist':4.8481e-6, 'Rs':1}
 
-#Define the host star properties
-host_star_properties = {'v_mag': 1, 'spectral_type': 'G2V', 'ra': 0, 'dec': 0}
+    #Create a Scene object that holds all this information
+    base_scene = scene.Scene(host_star_properties)
+    sim_scene = scene.SimulatedScene(base_scene)
 
-#Create a Scene object that holds all this information
-base_scene = scene.Scene(host_star_properties)
+    ####setup the wavelength for the simulation, nlam=1 for monochromatic image, nlam>1 for broadband image
+    lam0 = 575  # unit nm
+    #nlam = 7
+    nlam = 1
+    
+    if nlam > 1:
+        ####simulate broadband image
+        bandwidth = 0.1 
+        minlam = lam0 * (1 - bandwidth/2)
+        maxlam = lam0 * (1 + bandwidth/2)
+        lam_array = np.linspace( minlam, maxlam, nlam )  ### array of wavelength in nm
 
-##########################################
-### Define the state of the instrument ###
-##########################################
+    if nlam ==1:
+        ####simulate monochramtic image
+        lam_array = np.array([lam0])
 
-#Set up the configuration of the instrument and the detector
-proper_keywords = {"filter":"Band 1","roll_angle": 36.5, "dm1_filename": "dm1.fits", "dm2_filename": "dm2.fits"}
-emccd_keywords = {"read_noise": 3}
 
-# Set up the optics
-optics = instrument.CorgiOptics(proper_keywords)
+    cases = ['3e-8']       
+    rootname = 'hlc_ni_' + cases[0]
+    dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
+    dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
 
-# Set up the detector
-detector = instrument.CorgiDetector(emccd_keywords)
+    npsf = 256
+    final_sampling = 0.1
+    proper_keywords ={'cor_type':'hlc', 'use_errors':2, 'polaxis':10, 'final_sampling_lam0':final_sampling,\
+                       'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1,\
+                       'npsf':npsf, 'if_quiet':0, 'if_print_intensity':1 }
 
-##########################
-### Simulate the scene ###
-##########################
+    optics = instrument.CorgiOptics(lam_array, proper_keywords=proper_keywords)
+    optics.get_psf(base_scene, sim_scene)
 
-# Populate scene.host_star_image with an astropy HDU that contains a noiseless on-axis PSF
-simulated_scene_with_psf = optics.get_psf(base_scene, on_the_fly=True, oversample = 1, return_oversample = False)
-total_scene = scene.combine_simulated_scence_list(simulated_scene_with_psf)
+    print('Final_intensity_get:', np.sum(sim_scene.host_star_image, dtype = np.float64))
 
-############################
-### Simulate the readout ###
-############################
-#Final Image should be an HDU with the image in the first extension and the 0th extension contains the L1 header information. 
-final_image = detector.generate_detector_image(total_scene)
+    fig = plt.figure()
+    plt.imshow(sim_scene.host_star_image)
+    plt.colorbar()
+    plt.show()
+
+
+    exit()
+
+    ##########################################
+    ### Define the state of the instrument ###
+    ##########################################
+
+    #Set up the configuration of the instrument and the detector
+    proper_keywords = {"filter":"Band 1","roll_angle": 36.5, "dm1_filename": "dm1.fits", "dm2_filename": "dm2.fits"}
+    emccd_keywords = {"read_noise": 3}
+
+    # Set up the optics
+    optics = instrument.CorgiOptics(proper_keywords)
+
+    # Set up the detector
+    detector = instrument.CorgiDetector(emccd_keywords)
+
+    ##########################
+    ### Simulate the scene ###
+    ##########################
+
+    # Populate scene.host_star_image with an astropy HDU that contains a noiseless on-axis PSF
+    simulated_scene_with_psf = optics.get_psf(base_scene, on_the_fly=True, oversample = 1, return_oversample = False)
+    total_scene = scene.combine_simulated_scence_list(simulated_scene_with_psf)
+
+    ############################
+    ### Simulate the readout ###
+    ############################
+    #Final Image should be an HDU with the image in the first extension and the 0th extension contains the L1 header information. 
+    final_image = detector.generate_detector_image(total_scene)
+
+
+if __name__ == '__main__':
+    run_sim()
+
+
+
 
 

--- a/examples/example_on_axis_star.py
+++ b/examples/example_on_axis_star.py
@@ -52,10 +52,11 @@ def run_sim():
     optics = instrument.CorgiOptics(lam_array, proper_keywords=proper_keywords)
     sim_scene = optics.get_psf(base_scene)
 
-    print('Final_intensity_get:', np.sum(sim_scene.host_star_image, dtype = np.float64))
+    #print('Final_intensity_get:', np.sum(sim_scene.host_star_image, dtype = np.float64))
+    print(sim_scene.host_star_image[1].header)
 
     fig = plt.figure()
-    plt.imshow(sim_scene.host_star_image)
+    plt.imshow(sim_scene.host_star_image[1].data)
     plt.colorbar()
     plt.show()
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import platform
+
+from setuptools import find_packages, setup, Extension
+
+copy_args = sys.argv[1:]
+#copy_args.append('--user')
+ 
+ext_modules = []
+
+setup(
+      name="corgisim",
+      version = "0.0.1",
+      packages=find_packages(),
+
+      install_requires = ['numpy>=1.8', 'scipy>=0.19', 'astropy>=1.3', 'PyPROPER3>=3.3'],
+
+      package_data = {
+        '': ['*.*']
+      },
+
+      script_args = copy_args,
+
+      zip_safe = False, 
+
+      # Metadata for upload to PyPI
+      author="Jingwen Zhang, Max Millar-Blanchaer,...",
+      #author_email = "",
+      description="xxxx",
+      license = "BSD",
+      platforms=["any"],
+      url="",
+      ext_modules = ext_modules
+)
+

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
       author="Jingwen Zhang, Max Millar-Blanchaer,...",
       #author_email = "",
       description="xxxx",
-      license = "BSD",
+      license = "xxxx",
       platforms=["any"],
       url="",
       ext_modules = ext_modules


### PR DESCRIPTION
I've simplified the HDU features. The updated code now passes simulation-related keywords as headers to the HDU, including stellar properties and self.proper_keywords. However, I encountered a warning indicating that some keyword names are too long for a standard FITS header if copied directly from self.proper_keywords. While this works for now, we should discuss and finalize the header format at a later stage.

### One update: I used comment keyword to avoid the warning of long name for standard FITS header. 