### PR TITLE
Readme installation instructions change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,6 @@ Unzip them in you working directory. For each of them, enter the directory that 
 python -m pip install .
 ```
 
-### Install corgidrp
-
-Clone this directory:
-
-```
-git clone https://github.com/roman-corgi/corgidrp.git
-```
-
-Enter the directory that contains setup.py and run the following:
-
-``` 
-pip install -e .
-```
-
 ### Install corgisim
 
 Clone this directory:  

--- a/README.md
+++ b/README.md
@@ -18,18 +18,32 @@ Unzip them in you working directory. For each of them, enter the directory that 
 python -m pip install .
 ```
 
+### Install corgidrp
+
+Clone this directory:
+
+```
+git clone https://github.com/roman-corgi/corgidrp.git
+```
+
+Enter the directory that contains setup.py and run the following:
+
+``` 
+pip install -e .
+```
 
 ### Install corgisim
-```
-pip install -r requirements.txt 
-```
 
 Clone this directory:  
 
 ```
 git clone https://github.com/roman-corgi/corgisim.git
 ```
+
 Enter the directory that contains setup.py and run the following:
+```
+pip install -r requirements.txt 
+```
 ``` 
 pip install -e .
 ```


### PR DESCRIPTION
When doing a fresh install I found that there was an order of operations issue with the requirements.txt step.  