### PR TITLE
add_spec_simulation_4_host_star

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -214,9 +214,19 @@ class CorgiOptics():
 
                 images[i,:,:] = images[i,:,:] * counts
 
-        image = np.sum(images, axis=0)
+            image = np.sum(images, axis=0)
 
-        if self.cgi_mode in ['spec', 'lowfs', 'excam_efield']:
+        if self.cgi_mode == 'spec':
+            ### add the code in this block to generate spec simulation for host star 
+            ## the sequence could be 1) generate the 3D array for the host star psf (x, y, lambda) and also x, and y are oversampled
+                                   # 2) call function apply_slit_mask()
+                                   # 3) call function apply_prism()
+                                   # 4) scale images by counts and collapse 3D array to 2D arrays
+                
+            pass
+
+
+        if self.cgi_mode in ['lowfs', 'excam_efield']:
             raise ValueError(f"The mode '{self.cgi_mode}' has not been implemented yet!")
         
         # Initialize SimulatedImage class to restore the output psf
@@ -441,6 +451,14 @@ class CorgiOptics():
         sim_scene.point_source_image = outputs.create_hdu( np.sum(point_source_image,axis=0), sim_info =sim_info)
 
         return sim_scene
+
+    def apply_slit_mask(self, _3d_array):
+        
+        pass
+
+    def apply_prism(self,_3d_array):
+        pass
+
 
     
 class CorgiDetector(): 


### PR DESCRIPTION
## Purpose
Add a `spec_mode` simulation function to `CorgiSim`.

## Summary of Changes
**Major update** in `instrument.py`:

### Tasks for Neil:
1. In `CorgiOptics.get_host_star_psf()`, add a new block for spectroscopy simulation under the condition:

   `if self.cgi_mode == 'spec':`

The processing sequence should be:

1) Generate a 3D PSF array for the host star with dimensions (x, y, λ), where x and y are oversampled.

2) Call self.apply_slit_mask() to apply the slit.

3)Call self.apply_prism() to simulate dispersion.

4) Scale the resulting images by counts and collapse the 3D cube into a final 2D array.

The final output should be a 2D array.

2. Add the functions apply_slit_mask() and apply_prism() to the CorgiOptics class. These functions should take in the 3D array and any additional inputs needed.

3. Add a new test file in the test/ directory to validate the newly added spectroscopy functions.

###Task for Jingwen:

4. Write the 2D output array to an HDU within the SimulatedImage() class.
Question for Max: Should we create a new attribute such as self.host_star_image_spec, or continue using self.host_star_image?

5. Update sim_info and header_info to populate FITS headers for Level 1 (L1) files accordingly.


