### PR TITLE
fix_a bug_about_output_dim

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -204,6 +204,8 @@ class CorgiOptics():
                 else:
                     ## integrate oversampled PSF back to one grid per pixel
                     images[i,:,:] +=  images_tem[i,:,:].reshape((self.grid_dim_out,self.oversampling_factor,self.grid_dim_out,self.oversampling_factor)).mean(3).mean(1) * self.oversampling_factor**2
+                    ## update the proper_keywords['output_dim'] baclk to non_oversample size
+                    self.proper_keywords['output_dim'] = self.grid_dim_out
 
                 dlam_um = self.lam_um[1]-self.lam_um[0]
                 lam_um_l = (self.lam_um[i]- 0.5*dlam_um) * 1e4 ## unit of anstrom
@@ -235,7 +237,7 @@ class CorgiOptics():
                     'bandpass':self.bandpass_header,
                     'over_sampling_factor':self.oversampling_factor,
                     'return_oversample': self.return_oversample,
-                    'output_dim': self.grid_dim_out,
+                    'output_dim': self.proper_keywords['output_dim'],
                     'nd_filter':self.nd}
 
         # Define specific keys from self.proper_keywords to include in the header            
@@ -390,6 +392,9 @@ class CorgiOptics():
                     else:
                         ## integrate oversampled PSF back to one grid per pixel
                         images[i,:,:] +=  images_tem[i,:,:].reshape((self.grid_dim_out,self.oversampling_factor,self.grid_dim_out,self.oversampling_factor)).mean(3).mean(1) * self.oversampling_factor**2
+                        ## update the proper_keywords['output_dim'] baclk to non_oversample size
+                        self.proper_keywords['output_dim'] = self.grid_dim_out
+
 
                     dlam_um = self.lam_um[1]-self.lam_um[0]
                     lam_um_l = (self.lam_um[i]- 0.5*dlam_um) * 1e4 ## unit of anstrom
@@ -427,7 +432,7 @@ class CorgiOptics():
         sim_info['bandpass'] = self.bandpass_header
         sim_info['over_sampling_factor'] = self.oversampling_factor
         sim_info['return_oversample'] = self.return_oversample
-        sim_info['output_dim'] = self.grid_dim_out
+        sim_info['output_dim'] = self.proper_keywords['output_dim'] 
         sim_info['nd_filter'] = self.nd
                             
                 # Define specific keys from self.proper_keywords to include in the header            

--- a/test/test_off_axis_source.py
+++ b/test/test_off_axis_source.py
@@ -55,8 +55,10 @@ def test_off_axis_source():
     optics = instrument.CorgiOptics(cgi_mode,  bandpass_corgisim, proper_keywords=proper_keywords, if_quiet=True)
     sim_scene = optics.get_host_star_psf(base_scene)
     image_star_corgi = sim_scene.host_star_image.data
+    assert optics.proper_keywords['output_dim'] == proper_keywords['output_dim'], f"output_dim={proper_keywords['output_dim']}, but got {optics.proper_keywords['output_dim']}"
 
     sim_scene = optics.inject_point_sources(base_scene,sim_scene)
+    assert optics.proper_keywords['output_dim'] == proper_keywords['output_dim'], f"output_dim={proper_keywords['output_dim']}, but got {optics.proper_keywords['output_dim']}"
     image_comp_corgi = sim_scene.point_source_image.data 
     tot_counts_corgi = np.sum(image_comp_corgi+image_star_corgi, dtype = np.float64)
 


### PR DESCRIPTION
Sophie pointed out that even when we rescale the output image back to 1 grid per pixel (i.e., when `self.return_oversample=False`), the `proper_keyword['out_dim']` is not updated and still reflects the size of the oversampled image. I’ve fixed this bug in this branch.