### PR TITLE
75 argument copy

### DIFF
--- a/corgisim/inputs.py
+++ b/corgisim/inputs.py
@@ -5,7 +5,7 @@ from astropy.io import fits
 from corgidrp import mocks
 import numpy as np
 import roman_preflight_proper as rp
-
+import types
 class Input():
     """
     A class that holds all the information necessary for a simulation.
@@ -176,9 +176,11 @@ class Input():
         for key in list(host_star_properties_default):
             host_star_properties_default[key[1:]] = host_star_properties_default.pop(key)
 
-        self._proper_keywords = proper_keywords_default.copy()
-        self._emccd_keywords = emccd_keywords_default.copy()
-        self._host_star_properties = host_star_properties_default.copy()
+
+        # Create mutable copies for internal use during initialization
+        self.__mutable_proper_keywords = proper_keywords_default.copy()
+        self.__mutable_emccd_keywords = emccd_keywords_default.copy()
+        self.__mutable_host_star_properties = host_star_properties_default.copy()
 
         # Remaining Inputs for scene 
         self._point_source_info = None
@@ -202,7 +204,7 @@ class Input():
         # Update dictionaries
         if 'proper_keywords' in kwargs : 
             new_proper_keywords = kwargs['proper_keywords'].copy()
-            self._proper_keywords.update(new_proper_keywords)
+            self.__mutable_proper_keywords.update(new_proper_keywords)
             # Put dictionary value into attributes
             for key in list(kwargs['proper_keywords']):
                 new_proper_keywords['_'+key] = new_proper_keywords.pop(key)    
@@ -212,7 +214,7 @@ class Input():
 
         if 'emccd_keywords' in kwargs : 
             new_emccd_keywords = kwargs['emccd_keywords'].copy()
-            self._emccd_keywords.update(kwargs['emccd_keywords'])
+            self.__mutable_emccd_keywords.update(kwargs['emccd_keywords'])
             # Put dictionary value into attributes
             for key in list(kwargs['emccd_keywords']):
                 new_emccd_keywords['_'+key] = new_emccd_keywords.pop(key)    
@@ -222,7 +224,7 @@ class Input():
 
         if 'host_star_properties' in kwargs : 
             new_host_star_properties = kwargs['host_star_properties'].copy()
-            self._host_star_properties.update(kwargs['host_star_properties'])
+            self.__mutable_host_star_properties.update(kwargs['host_star_properties'])
             # Put dictionary value into attributes
             for key in list(kwargs['host_star_properties']):
                 new_host_star_properties['_'+key] = new_host_star_properties.pop(key)    
@@ -236,13 +238,17 @@ class Input():
         
         # Make sure there are no discrepancies between dictionnaries and individual values
         for key, val in kwargs.items():
-            if key[1:] in list(proper_keywords_default):
-                self._proper_keywords[key[1:]] = val
-            elif key[1:] in list(emccd_keywords_default):
-                self._emccd_keywords[key[1:]] = val
-            elif key[1:] in list(host_star_properties_default):
-                self._host_star_properties[key[1:]] = val
+            if key[1:] in self.__mutable_proper_keywords:
+                self.__mutable_proper_keywords[key[1:]] = val
+            elif key[1:] in self.__mutable_emccd_keywords:
+                self.__mutable_emccd_keywords[key[1:]] = val
+            elif key[1:] in self.__mutable_host_star_properties:
+                self.__mutable_host_star_properties[key[1:]] = val
 
+        # Now, create the immutable views of the dictionaries
+        self._proper_keywords = types.MappingProxyType(self.__mutable_proper_keywords)
+        self._emccd_keywords = types.MappingProxyType(self.__mutable_emccd_keywords)
+        self._host_star_properties = types.MappingProxyType(self.__mutable_host_star_properties)
 
         self._initialized = True
         

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -51,11 +51,12 @@ class CorgiOptics():
         - KeyError: If forbidden keywords are included.
         """
         '''
-        proper_keywords_internal = proper_keywords.copy()
+        
          # Initialize proper_keywords safely
-        if proper_keywords_internal is None:
-            proper_keywords_internal = {}
-
+        if proper_keywords is None:
+            raise KeyError(f"ERROR: proper_keywords are required to create an Optics object")
+        
+        proper_keywords_internal = proper_keywords.copy()
         #some parameters to the PROPER prescription are required, including 'cor_type', 'polaxis'
         required_keys = {'cor_type', 'polaxis', 'output_dim'}
         missing_keys = required_keys - proper_keywords_internal.keys()

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -51,7 +51,7 @@ class CorgiOptics():
         - KeyError: If forbidden keywords are included.
         """
         '''
-        proper_keywords_internal = copy.deepcopy(proper_keywords)
+        proper_keywords_internal = proper_keywords.copy()
          # Initialize proper_keywords safely
         if proper_keywords_internal is None:
             proper_keywords_internal = {}
@@ -488,9 +488,9 @@ class CorgiDetector():
         emccd_keywords: A dictionary with the keywords that are used to set up the emccd model
         photon_counting: if use photon_counting mode, default is True
         '''
-        self.emccd_keywords = copy.deepcopy(emccd_keywords)  # Store the keywords for later use
+        self.emccd_keywords = emccd_keywords.copy()  # Store the keywords for later use
         #self.exptime = exptime ##expsoure time in second
-        self.photon_counting = copy.deepcopy(photon_counting)
+        self.photon_counting = photon_counting
 
 
         self.emccd = self.define_EMCCD(emccd_keywords=self.emccd_keywords)

--- a/corgisim/scene.py
+++ b/corgisim/scene.py
@@ -55,7 +55,7 @@ class Scene():
     def __init__(self, host_star_properties=None, point_source_info=None, twoD_scene_hdu=None):
 
         host_star_properties_internal = host_star_properties.copy()
-        point_source_info_internal = copy.deepcopy(point_source_info)
+        point_source_info_internal = point_source_info.copy()
         self._host_star_Vmag = host_star_properties_internal['Vmag']  ## host star Vband magnitude
 
         # Validate the magnitude type
@@ -95,7 +95,7 @@ class Scene():
                                                                             magtype=self._point_source_magtype)
 
         
-        self._twoD_scene = copy.deepcopy(twoD_scene_hdu)
+        self._twoD_scene = twoD_scene_hdu.copy()
 
         
     @property

--- a/corgisim/scene.py
+++ b/corgisim/scene.py
@@ -54,8 +54,21 @@ class Scene():
     '''
     def __init__(self, host_star_properties=None, point_source_info=None, twoD_scene_hdu=None):
 
+        if host_star_properties is None:
+            raise KeyError(f"ERROR: host_star_properties are required to create a Scene object")
+
         host_star_properties_internal = host_star_properties.copy()
-        point_source_info_internal = point_source_info.copy()
+
+        if point_source_info is not None:
+            point_source_info_internal = point_source_info.copy()
+        else:
+            point_source_info_internal = None
+
+        if twoD_scene_hdu is not None:
+            self._twoD_scene = twoD_scene_hdu.copy()
+        else:
+            self._twoD_scene = None  
+              
         self._host_star_Vmag = host_star_properties_internal['Vmag']  ## host star Vband magnitude
 
         # Validate the magnitude type
@@ -95,8 +108,6 @@ class Scene():
                                                                             magtype=self._point_source_magtype)
 
         
-        self._twoD_scene = twoD_scene_hdu.copy()
-
         
     @property
     def host_star_sptype(self):

--- a/corgisim/scene.py
+++ b/corgisim/scene.py
@@ -54,7 +54,7 @@ class Scene():
     '''
     def __init__(self, host_star_properties=None, point_source_info=None, twoD_scene_hdu=None):
 
-        host_star_properties_internal = copy.deepcopy(host_star_properties)
+        host_star_properties_internal = host_star_properties.copy()
         point_source_info_internal = copy.deepcopy(point_source_info)
         self._host_star_Vmag = host_star_properties_internal['Vmag']  ## host star Vband magnitude
 

--- a/test/test_on_axis_star.py
+++ b/test/test_on_axis_star.py
@@ -7,6 +7,7 @@ import proper
 import roman_preflight_proper
 import pytest
 import cgisim
+import copy 
 
 #######################
 ### Set up a scene. ###
@@ -16,7 +17,6 @@ def test_on_axis_star():
     print('testrun')
     
     #Define the host star properties
-    #host_star_properties = {'v_mag': 1, 'spectral_type': 'G2V', 'ra': 0, 'dec': 0}
     Vmag = 8
     sptype = 'G0V'
     cgi_mode = 'excam'
@@ -36,13 +36,23 @@ def test_on_axis_star():
 
     proper_keywords ={'cor_type':cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':201,\
                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
-   
+    proper_keywords_copy = copy.deepcopy(proper_keywords)
     optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, proper_keywords=proper_keywords, if_quiet=True, integrate_pixels=True)
     sim_scene = optics.get_host_star_psf(base_scene)
+    
+    for key, value in proper_keywords.items():
+        if key not in proper_keywords_copy.keys():
+            pytest.fail(f'proper keywords have been changed')
+        else:
+            if isinstance(proper_keywords[key], np.ndarray) :
+                assert (proper_keywords_copy[key] == proper_keywords_copy[key]).all
+            else:
+                assert proper_keywords_copy[key] == proper_keywords_copy[key]
+
     image = sim_scene.host_star_image.data
     print('Final_intensity_get:', np.sum(image, dtype = np.float64))
-    #print(sim_scene.host_star_image[1].header)
-    #print(sim_scene.host_star_image[0].header)
+ 
+ 
 
     ########################  simulate using cgisim
     polaxis_cgisim = -10


### PR DESCRIPTION
Makes a copy of the arguments used in init. The goal is to avoid changing mutable types (like dictionary) inside an object (like an optic) improperly. 
The Input class is also modified so that an instance dictionaries cannot be changed through (for instance) input._proper_keywords[key] = new_value.
A test is added in test/test_on_axis_star.py to insure that the proper_keywords are no longer modified. 