### PR TITLE
populate headers to spec mode

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -158,7 +158,8 @@ class CorgiOptics():
 
             else:
                 warnings.warn("No prism selected in spec mode, the dispersion model will not be applied to the image cube.")
-
+            
+            ### give a warning if the prism is not the default one for the bandpass
             if (self.prism == 'PRISM2')&('3' in self.bandpass):
                 warnings.warn("PRISM2 is selected for Band 3, which is not the default setting for the Roman CGI, but it can still be simulated with CorgiSim.")
             if (self.prism == 'PRISM3')&('2' in self.bandpass):

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -75,10 +75,10 @@ class CorgiOptics():
 
         valid_cgi_modes = ['excam', 'spec', 'lowfs', 'excam_efield']
         valid_cor_types = ['hlc', 'hlc_band1', 'spc-wide', 'spc-wide_band4', 
-                        'spc-wide_band1', 'hlc_band2', 'hlc_band3', 'hlc_band4', 'spc-spec_rotated', 'spc-spec_band2_rotated', 'spc-spec_band3_rotated']
+                        'spc-wide_band1', 'hlc_band2', 'hlc_band3', 'hlc_band4','spc-spec', 'spc-spec_band2', 'spc-spec_band3' ]
         
         #these cor_type is availbale in cgisim, but are currently untested in corgisim
-        untest_cor_types = ['spc-spec', 'spc-spec_band2', 'spc-spec_band3', 'spc-mswc', 'spc-mswc_band4','spc-mswc_band1', 'zwfs']
+        untest_cor_types = ['spc-spec_rotated', 'spc-spec_band2_rotated', 'spc-spec_band3_rotated','spc-mswc', 'spc-mswc_band4','spc-mswc_band1', 'zwfs']
 
 
         if cgi_mode not in valid_cgi_modes:
@@ -361,7 +361,8 @@ class CorgiOptics():
 
         # Define specific keys from self.optics_keywords to include in the header            
         keys_to_include_in_header = ['use_errors','polaxis','final_sampling_m', 'use_dm1','use_dm2','use_fpm',
-                            'use_lyot_stop','use_field_stop','fsm_x_offset_mas','fsm_y_offset_mas']  # Specify keys to include
+                            'use_lyot_stop','use_field_stop','fsm_x_offset_mas','fsm_y_offset_mas','slit','prism',
+                            'slit_x_offset_mas','slit_y_offset_mas']  # Specify keys to include
         subset = {key: self.optics_keywords[key] for key in keys_to_include_in_header if key in self.optics_keywords}
         sim_info.update(subset)
         sim_info['includ_dectector_noise'] = 'False'
@@ -655,7 +656,8 @@ class CorgiOptics():
                             
                 # Define specific keys from self.optics_keywords to include in the header            
         keys_to_include_in_header = [ 'use_errors','polaxis','final_sampling_m', 'use_dm1','use_dm2','use_fpm',
-                            'use_lyot_stop','use_field_stop','fsm_x_offset_mas','fsm_y_offset_mas']  # Specify keys to include
+                            'use_lyot_stop','use_field_stop','fsm_x_offset_mas','fsm_y_offset_mas','slit','prism',
+                            'slit_x_offset_mas','slit_y_offset_mas']  # Specify keys to include
         subset = {key: self.optics_keywords[key] for key in keys_to_include_in_header if key in self.optics_keywords}
         sim_info.update(subset)
         sim_info['includ_dectector_noise'] = 'False'
@@ -766,13 +768,26 @@ class CorgiDetector():
                 ref_flag = False
             if (sim_info['ref_flag'] == 'True') or (sim_info['ref_flag'] == '1'):
                 ref_flag = True
+            if (sim_info['use_fpm'] == 'False') or (sim_info['use_fpm'] == '0'):
+                use_fpm = False
+            if (sim_info['use_fpm'] == 'True') or (sim_info['use_fpm'] == '1'):
+                use_fpm = True
+            
             header_info = {'EXPTIME': exptime,'EMGAIN_C':self.emccd_keywords_default['em_gain'],'PSFREF':ref_flag,
                            'PHTCNT':self.photon_counting,'KGAINPAR':self.emccd_keywords_default['e_per_dn'],'cor_type':sim_info['cor_type'], 'bandpass':sim_info['bandpass'],
-                           'cgi_mode': sim_info['cgi_mode'], 'polaxis':sim_info['polaxis']}
+                           'cgi_mode': sim_info['cgi_mode'], 'polaxis':sim_info['polaxis'],'use_fpm':use_fpm}
             if 'fsm_x_offset_mas' in sim_info:
                 header_info['FSMX'] = float(sim_info['fsm_x_offset_mas'])
             if 'fsm_y_offset_mas' in sim_info:
                 header_info['FSMY'] = float(sim_info['fsm_y_offset_mas'])
+            if 'slit' in sim_info:
+                header_info['slit'] = sim_info['slit']
+            else:
+                header_info['slit'] = None
+            if 'prism' in sim_info:
+                header_info['prism'] = sim_info['prism']
+            else:
+                header_info['prism'] = None
             simulated_scene.image_on_detector = outputs.create_hdu_list(Im_noisy, sim_info=sim_info, header_info = header_info)
         else:
             simulated_scene.image_on_detector = outputs.create_hdu(Im_noisy, sim_info=sim_info)

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -17,6 +17,7 @@ from corgisim import outputs
 from corgisim import spec
 import os
 from scipy import interpolate
+import warnings
 
 class CorgiOptics():
     '''
@@ -154,12 +155,24 @@ class CorgiOptics():
                     raise FileNotFoundError(f"Prism parameter file {prism_param_fname} does not exist")
                 else:
                     setattr(self, 'prism_param_fname', prism_param_fname)
+
+            else:
+                warnings.warn("No prism selected in spec mode, the dispersion model will not be applied to the image cube.")
+
+            if (self.prism == 'PRISM2')&('3' in self.bandpass):
+                warnings.warn("PRISM2 is selected for Band 3, which is not the default setting for the Roman CGI, but it can still be simulated with CorgiSim.")
+            if (self.prism == 'PRISM3')&('2' in self.bandpass):
+                warnings.warn("PRISM3 is selected for Band 2, which is not the default setting for the Roman CGI, but it can still be simulated with CorgiSim.")
+            
             if self.slit != 'None':
                 slit_param_fname = os.path.join(ref_data_dir, 'FSAM_slit_params.json')
                 if not os.path.exists(slit_param_fname):
                     raise FileNotFoundError(f"Slit aperture parameter file {slit_param_fname} does not exist")
                 else:
                     setattr(self, 'slit_param_fname', slit_param_fname)
+            else:
+                warnings.warn("No slit selected in spec mode, the slit mask will not be applied to the image cube.")
+            
 
         self.lam0_um = bandpass_data["lam0_um"] ##central wavelength of the filter in micron
         self.nlam = bandpass_data["nlam"] 

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -124,10 +124,16 @@ class CorgiOptics():
                 'prism': 'None', # named DPAM prism
                 'wav_step_um': 1E-3 # wavelength step size of the prism dispersion model, in microns 
             }
-            spec_kw_allowed = {
-                'slit': ['None', 'R1C2', 'R6C5', 'R3C1'],
-                'prism': ['None', 'PRISM3', 'PRISM2']
-            }
+            #### allowed slit for band2 
+            if '2' in self.bandpass:     
+                spec_kw_allowed = {
+                    'slit': ['None', 'R6C5', 'R3C1'],
+                    'prism': ['None', 'PRISM3', 'PRISM2']}
+            #### allowed slit for band3
+            elif '3' in self.bandpass:
+                spec_kw_allowed = {
+                    'slit': ['None', 'R1C2', 'R3C1'],
+                    'prism': ['None', 'PRISM3', 'PRISM2']}
             for attr_name, default_value in spec_kw_defaults.items():
                 if attr_name in optics_keywords:
                     value = optics_keywords[attr_name]

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -203,9 +203,20 @@ class CorgiOptics():
         self.return_oversample = return_oversample
 
 
-        self.nd = 0  # integer: 1, 3, or 4 (0 = no ND, the default); this is the ND filter identifier, NOT the amount of ND
-        if "nd" in kwargs: self.nd = kwargs.get("nd")
-
+        self.nd = 0  # integer: 1, 2, or 3 (0 = no ND, the default); this is the ND filter identifier, NOT the amount of ND
+        #if "nd" in kwargs: self.nd = kwargs.get("nd")
+        if "nd" in optics_keywords.keys():
+            if optics_keywords["nd"] ==1:
+                self.nd = '2.25'
+            elif optics_keywords["nd"] ==2:
+                self.nd = '4.75fpam'
+            elif optics_keywords["nd"] ==3:
+                self.nd = '4.75fsam'
+            elif optics_keywords["nd"] ==0:
+                self.nd = 0
+            else:
+                raise ValueError(f"Invalid ND filter value: {optics_keywords['nd']}. Must be 0, 1, 2, or 3.")
+            
         # Initialize the bandpass class (from synphot)
         # bp: wavelegth is in unit of angstrom
         # bp: throughput is unitless, including transmission, reflectivity and EMCCD quantum efficiency 
@@ -781,7 +792,7 @@ class CorgiDetector():
             
             header_info = {'EXPTIME': exptime,'EMGAIN_C':self.emccd_keywords_default['em_gain'],'PSFREF':ref_flag,
                            'PHTCNT':self.photon_counting,'KGAINPAR':self.emccd_keywords_default['e_per_dn'],'cor_type':sim_info['cor_type'], 'bandpass':sim_info['bandpass'],
-                           'cgi_mode': sim_info['cgi_mode'], 'polaxis':sim_info['polaxis'],'use_fpm':use_fpm}
+                           'cgi_mode': sim_info['cgi_mode'], 'polaxis':sim_info['polaxis'],'use_fpm':use_fpm,'nd_filter':sim_info['nd_filter']}
             if 'fsm_x_offset_mas' in sim_info:
                 header_info['FSMX'] = float(sim_info['fsm_x_offset_mas'])
             if 'fsm_y_offset_mas' in sim_info:

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -82,7 +82,7 @@ def create_hdu_list(data, header_info, sim_info=None):
     
     ##### need to update later
     exthdr['FPAM_H'], exthdr['FPAM_V'], exthdr['FPAMNAME'], exthdr['FPAMSP_H'],exthdr['FPAMSP_V'] = write_headers_FPAM(header_info['cor_type'], header_info['bandpass'], header_info['use_fpm'])
-    exthdr['FSAM_H'], exthdr['FSAM_V'], exthdr['FSAMNAME'], exthdr['FSAMSP_H'],exthdr['FSAMSP_V'] = write_headers_FSAM(header_info['cor_type'], header_info['bandpass'], header_info['slit'])
+    exthdr['FSAM_H'], exthdr['FSAM_V'], exthdr['FSAMNAME'], exthdr['FSAMSP_H'],exthdr['FSAMSP_V'] = write_headers_FSAM(header_info['cor_type'], header_info['bandpass'], header_info['slit'], header_info['polaxis'])
 
 
 
@@ -416,14 +416,20 @@ def write_headers_DPAM(cor_mode, polaxis, prism):
             DPAMNAME = 'PRISM2'
             DPAMSP_H = 62496
             DPAMSP_V = 1261.3
-        elif prism == 'PRISM3':
+        if prism == 'PRISM3':
             DPAM_H = 26824.2
             DPAM_V = 1261.3
             DPAMNAME = 'PRISM3'
             DPAMSP_H = 26824.2
             DPAMSP_V = 1261.3
-        else:
-            raise ValueError('Please specify the prism type when cor_mode is spec for simulation of formal L1 products')
+        if prism == 'None':
+            DPAM_H = 38917.1
+            DPAM_V = 26016.9
+            DPAMNAME = 'IMAGING'
+            DPAMSP_H = 38917.1
+            DPAMSP_V = 26016.9
+
+        
     if (cor_mode == 'excam') & (polaxis not in ['0', '10']):
         raise ValueError('Polarimetry mode has not been implemented')
 
@@ -520,7 +526,7 @@ def write_headers_FPAM(cor_type, band_pass,use_fpm):
     return FPAM_H, FPAM_V, FPAMNAME, FPAMSP_H, FPAMSP_V
 
 
-def write_headers_FSAM(cor_type, band_pass,slit):
+def write_headers_FSAM(cor_type, band_pass,slit,polaxis):
 
     ### determine the value for FSAM based on coronagraph type and bandpass
     if 'hlc' in cor_type:
@@ -553,12 +559,14 @@ def write_headers_FSAM(cor_type, band_pass,slit):
             FSAMSP_V = 21238
 
     if 'wide' in cor_type:
-        
-        FSAM_H = 6687
-        FSAM_V = 13738
-        FSAMNAME = 'R1C5'
-        FSAMSP_H = 6687
-        FSAMSP_V = 13738
+        if polaxis in ['0', '10']:
+            FSAM_H =30677.2
+            FSAM_V = 2959.5
+            FSAMNAME = 'OPEN'
+            FSAMSP_H = 30677.2
+            FSAMSP_V = 2959.5
+        else:
+            raise ValueError("Polarimetry mode has not been implemented for FSAM")
 
     if ('spec' in cor_type) & ('rotated' not in cor_type):
         if '2' in band_pass:
@@ -574,8 +582,13 @@ def write_headers_FSAM(cor_type, band_pass,slit):
                 FSAMNAME = 'R3C1'
                 FSAMSP_H = 26937
                 FSAMSP_V = 21238
-            else:
-                raise ValueError("Please specify the slit type when spec mode for simulation of formal L1 products")
+            if slit == "None":
+                FSAM_H =30677.2
+                FSAM_V = 2959.5
+                FSAMNAME = 'OPEN'
+                FSAMSP_H = 30677.2
+                FSAMSP_V = 2959.5
+                
 
         if '3' in band_pass:
             if slit == "R1C2":
@@ -590,8 +603,12 @@ def write_headers_FSAM(cor_type, band_pass,slit):
                 FSAMNAME = 'R3C1'
                 FSAMSP_H = 26937
                 FSAMSP_V = 21238
-            else:
-                raise ValueError("Please specify the slit type when spec mode for simulation of formal L1 products")
+            if slit == "None":
+                FSAM_H =30677.2
+                FSAM_V = 2959.5
+                FSAMNAME = 'OPEN'
+                FSAMSP_H = 30677.2
+                FSAMSP_V = 2959.5
 
     if 'rotated' in cor_type:
         if '2' in band_pass:

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -81,7 +81,7 @@ def create_hdu_list(data, header_info, sim_info=None):
     exthdr['DPAM_H'], exthdr['DPAM_V'], exthdr['DPAMNAME'], exthdr['DPAMSP_H'],exthdr['DPAMSP_V'] = write_headers_DPAM(header_info['cgi_mode'], header_info['polaxis'], header_info['prism'])
     
     ##### need to update later
-    exthdr['FPAM_H'], exthdr['FPAM_V'], exthdr['FPAMNAME'], exthdr['FPAMSP_H'],exthdr['FPAMSP_V'] = write_headers_FPAM(header_info['cor_type'], header_info['bandpass'], header_info['use_fpm'])
+    exthdr['FPAM_H'], exthdr['FPAM_V'], exthdr['FPAMNAME'], exthdr['FPAMSP_H'],exthdr['FPAMSP_V'] = write_headers_FPAM(header_info['cor_type'], header_info['bandpass'], header_info['use_fpm'], header_info['nd_filter'])
     exthdr['FSAM_H'], exthdr['FSAM_V'], exthdr['FSAMNAME'], exthdr['FSAMSP_H'],exthdr['FSAMSP_V'] = write_headers_FSAM(header_info['cor_type'], header_info['bandpass'], header_info['slit'], header_info['polaxis'])
 
 
@@ -435,15 +435,38 @@ def write_headers_DPAM(cor_mode, polaxis, prism):
 
     return DPAM_H, DPAM_V, DPAMNAME,  DPAMSP_H,  DPAMSP_V
 
-def write_headers_FPAM(cor_type, band_pass,use_fpm):
+def write_headers_FPAM(cor_type, band_pass,use_fpm,nd_filter):
     ### determine the value for FPAM based on coronagraph type and bandpass, and if use fpm
     if not use_fpm:
-        FPAM_H = -9999
-        FPAM_V = -9999
-        FPAMNAME = 'N/A'
-        FPAMSP_H = -9999
-        FPAMSP_V = -9999
-
+        ## not using foca plane mask, typically for non-occulted stars
+        if (nd_filter == '0'):
+            ## no ND filter
+            if ('1' in band_pass) or ('2' in band_pass):
+                FPAM_H = 3509.4
+                FPAM_V = 32824.7
+                FPAMNAME = 'OPEN_12'
+                FPAMSP_H = 3509.4
+                FPAMSP_V = 32824.7
+            if ('3' in band_pass) or ('4' in band_pass):
+                FPAM_H = 60251.2
+                FPAM_V = 2248.5
+                FPAMNAME = 'OPEN_34'
+                FPAMSP_H = 60251.2
+                FPAMSP_V = 2248.5
+        if (nd_filter == '1'):
+            ## ND filter1 
+            FPAM_H = 61507.8
+            FPAM_V = 25612.4
+            FPAMNAME = 'ND225'
+            FPAMSP_H = 61507.8
+            FPAMSP_V = 25612.4
+        if (nd_filter == '2'):
+            ## ND filter2
+            FPAM_H = 2503.7
+            FPAM_V = 6124.9
+            FPAMNAME = 'ND475'
+            FPAMSP_H = 2503.7
+            FPAMSP_V = 6124.9
     else:
         if 'hlc' in cor_type:
             ##hlc NFOV imaging mode

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -2,7 +2,7 @@ from astropy.io import fits
 from corgidrp import mocks
 import os
 from datetime import datetime, timezone, timedelta
-import warnings
+#import warnings
 
 def create_hdu_list(data, header_info, sim_info=None):
     """

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -2,6 +2,7 @@ from astropy.io import fits
 from corgidrp import mocks
 import os
 from datetime import datetime, timezone, timedelta
+import warnings
 
 def create_hdu_list(data, header_info, sim_info=None):
     """
@@ -77,11 +78,11 @@ def create_hdu_list(data, header_info, sim_info=None):
     exthdr['SPAM_H'], exthdr['SPAM_V'], exthdr['SPAMNAME'], exthdr['SPAMSP_H'],exthdr['SPAMSP_V'] = write_headers_SPAM(header_info['cor_type'])
     exthdr['LSAM_H'], exthdr['LSAM_V'], exthdr['LSAMNAME'], exthdr['LSAMSP_H'],exthdr['LSAMSP_V'] = write_headers_LSAM(header_info['cor_type'])
     exthdr['CFAM_H'], exthdr['CFAM_V'], exthdr['CFAMNAME'], exthdr['CFAMSP_H'],exthdr['CFAMSP_V'] = write_headers_CFAM(header_info['bandpass'])
-    exthdr['DPAM_H'], exthdr['DPAM_V'], exthdr['DPAMNAME'], exthdr['DPAMSP_H'],exthdr['DPAMSP_V'] = write_headers_DPAM(header_info['cgi_mode'], header_info['polaxis'])
+    exthdr['DPAM_H'], exthdr['DPAM_V'], exthdr['DPAMNAME'], exthdr['DPAMSP_H'],exthdr['DPAMSP_V'] = write_headers_DPAM(header_info['cgi_mode'], header_info['polaxis'], header_info['prism'])
     
     ##### need to update later
-    exthdr['FPAM_H'], exthdr['FPAM_V'], exthdr['FPAMNAME'], exthdr['FPAMSP_H'],exthdr['FPAMSP_V'] = write_headers_FPAM(header_info['cor_type'], header_info['bandpass'])
-    exthdr['FSAM_H'], exthdr['FSAM_V'], exthdr['FSAMNAME'], exthdr['FSAMSP_H'],exthdr['FSAMSP_V'] = write_headers_FSAM(header_info['cor_type'], header_info['bandpass'])
+    exthdr['FPAM_H'], exthdr['FPAM_V'], exthdr['FPAMNAME'], exthdr['FPAMSP_H'],exthdr['FPAMSP_V'] = write_headers_FPAM(header_info['cor_type'], header_info['bandpass'], header_info['use_fpm'])
+    exthdr['FSAM_H'], exthdr['FSAM_V'], exthdr['FSAMNAME'], exthdr['FSAMSP_H'],exthdr['FSAMSP_V'] = write_headers_FSAM(header_info['cor_type'], header_info['bandpass'], header_info['slit'])
 
 
 
@@ -200,6 +201,7 @@ def write_headers_SPAM(cor_type):
 
     ### determine the value for SPAM based on coronagraph type
     if 'hlc' in cor_type:
+        ## hlc NFOV imaging mode
         SPAM_H = 1001.3
         SPAM_V = 16627
         SPAMNAME = 'OPEN'
@@ -207,6 +209,7 @@ def write_headers_SPAM(cor_type):
         SPAMSP_V = 16627
 
     if 'wide' in cor_type:
+        ## spc WFOV imaging mode
         SPAM_H = 26254.7
         SPAM_V = 8657
         SPAMNAME = 'WFOV'
@@ -214,6 +217,7 @@ def write_headers_SPAM(cor_type):
         SPAMSP_V = 8657
 
     if ('spec' in cor_type) & ('rotated' not in cor_type):
+        ## spc spec mode, not rotated
         SPAM_H = 26250.4
         SPAM_V = 27254.4
         SPAMNAME = 'SPEC'
@@ -221,6 +225,7 @@ def write_headers_SPAM(cor_type):
         SPAMSP_V = 27254.4
 
     if 'rotated' in cor_type:
+        ## spc spec mode, rotated
         SPAM_H =44850.4
         SPAM_V = 8654.4
         SPAMNAME = 'SPECROT'
@@ -237,6 +242,7 @@ def write_headers_LSAM(cor_type):
 
     ### determine the value for LSAM based on coronagraph type
     if 'hlc' in cor_type:
+        ## hlc NFOV imaging mode
         LSAM_H = 36898.7
         LSAM_V = 4636.2
         LSAMNAME = 'NFOV'
@@ -244,6 +250,7 @@ def write_headers_LSAM(cor_type):
         LSAMSP_V = 4636.2
 
     if 'wide' in cor_type:
+        ## spc WFOV imaging mode
         LSAM_H = 1424.3
         LSAM_V = 29440.2
         LSAMNAME = 'WFOV'
@@ -251,6 +258,7 @@ def write_headers_LSAM(cor_type):
         LSAMSP_V = 29440.2
 
     if ('spec' in cor_type) & ('rotated' not in cor_type):
+        ## spc spec mode, not rotated
         LSAM_H = 36936.3
         LSAM_V = 29389.3
         LSAMNAME = 'SPEC'
@@ -258,6 +266,7 @@ def write_headers_LSAM(cor_type):
         LSAMSP_V = 29389.3
 
     if 'rotated' in cor_type:
+        ## spc spec mode, rotated
         LSAM_H =  1426.6
         LSAM_V = 4581.4
         LSAMNAME = 'SPECROT'
@@ -389,69 +398,95 @@ def write_headers_CFAM(band_pass):
     
     
 
-def write_headers_DPAM(cor_mode, polaxis):
+def write_headers_DPAM(cor_mode, polaxis, prism):
      ### determine the value for DPAM based on simulation mode and polaxis number
     
     if (cor_mode == 'excam') & (polaxis in ['0', '10']):
+        ## excam imaging mode, no polarimetry
         DPAM_H = 38917.1
         DPAM_V = 26016.9
         DPAMNAME = 'IMAGING'
         DPAMSP_H = 38917.1
         DPAMSP_V = 26016.9
     if cor_mode == 'spec':
-        raise ValueError('Spec mode has not been implemented')
+        #raise ValueError('Spec mode has not been implemented')
+        if prism == 'PRISM2':
+            DPAM_H = 62496
+            DPAM_V = 1261.3
+            DPAMNAME = 'PRISM2'
+            DPAMSP_H = 62496
+            DPAMSP_V = 1261.3
+        elif prism == 'PRISM3':
+            DPAM_H = 26824.2
+            DPAM_V = 1261.3
+            DPAMNAME = 'PRISM3'
+            DPAMSP_H = 26824.2
+            DPAMSP_V = 1261.3
+        else:
+            raise ValueError('Please specify the prism type when cor_mode is spec for simulation of formal L1 products')
     if (cor_mode == 'excam') & (polaxis not in ['0', '10']):
         raise ValueError('Polarimetry mode has not been implemented')
 
     return DPAM_H, DPAM_V, DPAMNAME,  DPAMSP_H,  DPAMSP_V
 
-def write_headers_FPAM(cor_type, band_pass):
-    ### determine the value for FPAM based on coronagraph type and bandpass
-    if 'hlc' in cor_type:
-        if '1' in band_pass:
-            FPAM_H = 6757.2
-            FPAM_V = 22424
-            FPAMNAME = 'HLC12_C2R1'
-            FPAMSP_H = 6757.2
-            FPAMSP_V = 22424
-        
-        if '2' in band_pass:
-            FPAM_H = 55306.4
-            FPAM_V = 9901.9
-            FPAMNAME = 'HLC34_R7C1'
-            FPAMSP_H = 55306.4
-            FPAMSP_V = 9901.9
+def write_headers_FPAM(cor_type, band_pass,use_fpm):
+    ### determine the value for FPAM based on coronagraph type and bandpass, and if use fpm
+    if not use_fpm:
+        FPAM_H = -9999
+        FPAM_V = -9999
+        FPAMNAME = 'N/A'
+        FPAMSP_H = -9999
+        FPAMSP_V = -9999
 
-        if '3' in band_pass:
-            FPAM_H = 52005.1
-            FPAM_V = 8004.2
-            FPAMNAME = 'HLC34_R5C1'
-            FPAMSP_H = 52005.1
-            FPAMSP_V = 8004.2
+    else:
+        if 'hlc' in cor_type:
+            ##hlc NFOV imaging mode
+            if '1' in band_pass:
+                FPAM_H = 6757.2
+                FPAM_V = 22424
+                FPAMNAME = 'HLC12_C2R1'
+                FPAMSP_H = 6757.2
+                FPAMSP_V = 22424
+            
+            if '2' in band_pass:
+                FPAM_H = 55306.4
+                FPAM_V = 9901.9
+                FPAMNAME = 'HLC34_R7C1'
+                FPAMSP_H = 55306.4
+                FPAMSP_V = 9901.9
 
-        if '4' in band_pass:
-            FPAM_H = 52003.8
-            FPAM_V = 6104.2
-            FPAMNAME = 'HLC34_R3C1'
-            FPAMSP_H = 52003.8
-            FPAMSP_V = 6104.2
+            if '3' in band_pass:
+                FPAM_H = 52005.1
+                FPAM_V = 8004.2
+                FPAMNAME = 'HLC34_R5C1'
+                FPAMSP_H = 52005.1
+                FPAMSP_V = 8004.2
 
-    if 'wide' in cor_type:
-        if '1' in band_pass:
-            FPAM_H = 23719.6
-            FPAM_V = 2278.1
-            FPAMNAME = 'SPC12_R1C1'
-            FPAMSP_H = 23719.6
-            FPAMSP_V = 2278.1
+            if '4' in band_pass:
+                FPAM_H = 52003.8
+                FPAM_V = 6104.2
+                FPAMNAME = 'HLC34_R3C1'
+                FPAMSP_H = 52003.8
+                FPAMSP_V = 6104.2
 
-        if '4' in band_pass:
-            FPAM_H = 35354.3
-            FPAM_V =27622.6
-            FPAMNAME = 'SPC34_R5C1'
-            FPAMSP_H = 35354.3
-            FPAMSP_V = 27622.6
+        if 'wide' in cor_type:
+            ##spc WFOV imaging mode
+            if '1' in band_pass:
+                FPAM_H = 23719.6
+                FPAM_V = 2278.1
+                FPAMNAME = 'SPC12_R1C1'
+                FPAMSP_H = 23719.6
+                FPAMSP_V = 2278.1
+
+            if '4' in band_pass:
+                FPAM_H = 35354.3
+                FPAM_V =27622.6
+                FPAMNAME = 'SPC34_R5C1'
+                FPAMSP_H = 35354.3
+                FPAMSP_V = 27622.6
 
         if ('spec' in cor_type) & ('rotated' not in cor_type):
+                ## spc spec mode, not rotated
             if '2' in band_pass:
                 FPAM_H = 25866.4
                 FPAM_V = 7129.5
@@ -467,6 +502,7 @@ def write_headers_FPAM(cor_type, band_pass):
                 FPAMSP_V = 22573
 
         if 'rotated' in cor_type:
+            ## spc spec mode, rotated
             if '2' in band_pass:
                 FPAM_H = 22666.4
                 FPAM_V = 7127.4
@@ -484,7 +520,7 @@ def write_headers_FPAM(cor_type, band_pass):
     return FPAM_H, FPAM_V, FPAMNAME, FPAMSP_H, FPAMSP_V
 
 
-def write_headers_FSAM(cor_type, band_pass):
+def write_headers_FSAM(cor_type, band_pass,slit):
 
     ### determine the value for FSAM based on coronagraph type and bandpass
     if 'hlc' in cor_type:
@@ -526,18 +562,36 @@ def write_headers_FSAM(cor_type, band_pass):
 
     if ('spec' in cor_type) & ('rotated' not in cor_type):
         if '2' in band_pass:
-            FSAM_H = 11187
-            FSAM_V = 17438
-            FSAMNAME = 'R2C5'
-            FSAMSP_H = 11187
-            FSAMSP_V = 17438
+            if slit == "R6C5":
+                FSAM_H = 11187
+                FSAM_V = 32638
+                FSAMNAME = 'R6C5'
+                FSAMSP_H = 11187
+                FSAMSP_V = 32638
+            elif slit == "R3C1":
+                FSAM_H = 26937
+                FSAM_V = 21238
+                FSAMNAME = 'R3C1'
+                FSAMSP_H = 26937
+                FSAMSP_V = 21238
+            else:
+                raise ValueError("Please specify the slit type when spec mode for simulation of formal L1 products")
 
         if '3' in band_pass:
-            FSAM_H = 24087
-            FSAM_V = 12238
-            FSAMNAME = 'R1C2'
-            FSAMSP_H = 24087
-            FSAMSP_V = 12238
+            if slit == "R1C2":
+                FSAM_H = 24087
+                FSAM_V = 12238
+                FSAMNAME = 'R1C2'
+                FSAMSP_H = 24087
+                FSAMSP_V = 12238
+            elif slit == "R3C1":
+                FSAM_H = 26937
+                FSAM_V = 21238
+                FSAMNAME = 'R3C1'
+                FSAMSP_H = 26937
+                FSAMSP_V = 21238
+            else:
+                raise ValueError("Please specify the slit type when spec mode for simulation of formal L1 products")
 
     if 'rotated' in cor_type:
         if '2' in band_pass:

--- a/test/test_L1_product_fits_format_specmode.py
+++ b/test/test_L1_product_fits_format_specmode.py
@@ -65,7 +65,7 @@ def test_L1_product_fits_format_specmode():
     overfac = 5
 
     optics_keywords_slit_prism ={'cor_type':cor_type, 'use_errors':2, 'polaxis':polaxis, 'output_dim':output_dim, 
-                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,
+                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,'nd':1,
                     'slit':'R1C2', 'slit_y_offset_mas':base_scene.point_source_y[0], 'prism':'PRISM3', 'wav_step_um':2E-3}
     optics_slit_prism = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords_slit_prism, if_quiet=True,
                                     small_spc_grid = 1, oversample = overfac, return_oversample = False)

--- a/test/test_L1_product_fits_format_specmode.py
+++ b/test/test_L1_product_fits_format_specmode.py
@@ -1,0 +1,148 @@
+from corgisim import scene
+from corgisim import instrument
+from astropy.io import fits
+import matplotlib.pyplot as plt
+import numpy as np
+import proper
+import roman_preflight_proper
+import pytest
+import cgisim
+import os
+import corgisim
+from corgisim import outputs
+
+def test_L1_product_fits_format_specmode():
+    """Test the headers of saved L1 product FITS file for spec mode
+    """
+    #print('testrun')
+    #### simulate using corgisim
+    #### testing the defalut value pass to header
+
+    Vmag = 6                            # V-band magnitude of the host star
+    sptype = 'G0V'                      # Spectral type of the host star
+    ref_flag = False                    # if the target is a reference star or not, default is False
+    host_star_properties = {'Vmag': Vmag,
+                            'spectral_type': sptype,
+                            'magtype': 'vegamag',
+                            'ref_flag': False}
+
+    # --- Companion Properties ---
+    mag_companion = [22]           # List of magnitudes for each companion
+
+    # Define their positions relative to the host star, in milliarcseconds (mas)
+    # For reference: 1 λ/D at 550 nm with a 2.3 m telescope is ~49.3 mas
+    mas_per_lamD = 63.72 # Band 3
+    dx = [2 * mas_per_lamD]         # X positions in mas for each companion
+    dy = [6 * mas_per_lamD]         # Y positions in mas for each companion
+
+    # Construct a list of dictionaries for all companion point sources
+    point_source_info = [
+        {
+            'Vmag': mag_companion[0],
+            'magtype': 'vegamag',
+            'position_x': dx[0],
+            'position_y': dy[0]
+        }
+    ]
+
+    # --- Create the Astrophysical Scene ---
+    # This Scene object combines the host star and companion(s)
+    base_scene = scene.Scene(host_star_properties, point_source_info)
+
+    cgi_mode = 'spec'
+    cor_type = 'spc-spec_band3'
+    bandpass = '3F'
+    cases = ['2e-8']      
+    # cases = ['1e-9']      
+    rootname = 'spc-spec_ni_' + cases[0]
+    dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
+    dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
+
+    ##  Define the polaxis parameter. Use 10 for non-polaxis cases only, as other options are not yet implemented.
+    polaxis = 10
+    # output_dim define the size of the output image
+    output_dim = 121
+    overfac = 5
+
+    optics_keywords_slit_prism ={'cor_type':cor_type, 'use_errors':2, 'polaxis':polaxis, 'output_dim':output_dim, 
+                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,
+                    'slit':'R1C2', 'slit_y_offset_mas':base_scene.point_source_y[0], 'prism':'PRISM3', 'wav_step_um':2E-3}
+    optics_slit_prism = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords_slit_prism, if_quiet=True,
+                                    small_spc_grid = 1, oversample = overfac, return_oversample = False)
+
+
+    sim_scene_slit_prism = optics_slit_prism.get_host_star_psf(base_scene)
+
+    sim_scene_slit_prism = optics_slit_prism.inject_point_sources(base_scene,sim_scene_slit_prism)
+
+    emccd_keywords ={'cr_rate':0.0}
+    exptime = 3000
+
+    detector = instrument.CorgiDetector( emccd_keywords)
+    sim_scene_slit_prism = detector.generate_detector_image(sim_scene_slit_prism, exptime,full_frame=True,loc_x=512, loc_y=512)
+
+    ### save the L1 product fits file to test/testdata folder
+    local_path = corgisim.lib_dir
+    outdir = os.path.join(local_path.split('corgisim')[0], 'corgisim/test/testdata')
+    outputs.save_hdu_to_fits(sim_scene_slit_prism.image_on_detector,outdir=outdir, write_as_L1=True)
+
+    ### read the L1 product fits file
+    prihdr = sim_scene_slit_prism.image_on_detector[0].header
+    exthdr = sim_scene_slit_prism.image_on_detector[1].header
+    time_in_name = outputs.isotime_to_yyyymmddThhmmsss(exthdr['FTIMEUTC'])
+    filename = f"CGI_{prihdr['VISITID']}_{time_in_name}_L1_.fits"
+
+
+    f = os.path.join( outdir , filename)
+
+    with fits.open(f) as hdul:
+        data = hdul[1].data
+        prihr = hdul[0].header
+        exthr = hdul[1].header
+        
+        # Check that the dtype is exactly uint16
+        assert exthdr['SPAM_H'] ==  26250.4, f"Expected data SPAM_H=26250.4, but got {exthdr['SPAM_H']}"
+        assert exthdr['SPAM_V']== 27254.4,  f"Expected data SPAM_V = 27254.4, but got {exthdr['SPAM_V']}"
+        assert exthdr['SPAMNAME'] =='SPEC' , f"Expected data SPAMNAME ='SPEC', but got {exthdr['SPAMNAME']}"
+        assert exthdr['SPAMSP_H']== 26250.4, f"Expected data SPAMSP_H=26250.4, but got {exthdr['SPAMSP_H']}"
+        assert exthdr['SPAMSP_V'] == 27254.4, f"Expected data SPAMSP_V=27254.4, but got {exthdr['SPAMSP_V']}"
+
+        assert exthdr['LSAM_H'] ==  36936.3, f"Expected data LSAM_H=36936.3, but got {exthdr['LSAM_H']}"
+        assert exthdr['LSAM_V']== 29389.3,  f"Expected data LSAM_V = 29389.3, but got {exthdr['LSAM_V']}"
+        assert exthdr['LSAMNAME'] =='SPEC' , f"Expected data LSAMNAME ='SPEC', but got {exthdr['LSAMNAME']}"
+        assert exthdr['LSAMSP_H']== 36936.3, f"Expected data LSAMSP_H=36936.3, but got {exthdr['LSAMSP_H']}"
+        assert exthdr['LSAMSP_V'] == 29389.3, f"Expected data LSAMSP_V=29389.3, but got {exthdr['LSAMSP_V']}"
+
+        assert exthdr['CFAM_H'] == 2329.2, f"Expected data CFAM_H=2329.2, but got {exthdr['CFAM_H']}"
+        assert exthdr['CFAM_V'] == 24002.7, f"Expected data CFAM_V=24002.7, but got {exthdr['CFAM_V']}"
+        assert exthdr['CFAMNAME'] == '3F', f"Expected data CFAMNAME='3F', but got {exthdr['CFAMNAME']}"
+        assert exthdr['CFAMSP_H'] == 2329.2, f"Expected data CFAMSP_H=2329.2, but got {exthdr['CFAMSP_H']}"
+        assert exthdr['CFAMSP_V'] == 24002.7, f"Expected data CFAMSP_V=24002.7, but got {exthdr['CFAMSP_V']}"
+
+        assert exthdr['DPAM_H'] == 26824.2, f"Expected data DPAM_H=26824.2, but got {exthdr['DPAM_H']}"
+        assert exthdr['DPAM_V'] == 1261.3, f"Expected data DPAM_V=1261.3, but got {exthdr['DPAM_V']}"
+        assert exthdr['DPAMNAME'] == 'PRISM3', f"Expected data DPAMNAME='PRISM3', but got {exthdr['DPAMNAME']}"
+        assert exthdr['DPAMSP_H'] == 26824.2, f"Expected data DPAMSP_H=26824.2, but got {exthdr['DPAMSP_H']}"
+        assert exthdr['DPAMSP_V'] == 1261.3, f"Expected data DPAMSP_V=1261.3, but got {exthdr['DPAMSP_V']}"
+
+        assert exthdr['FPAM_H'] ==  37005.5, f"Expected data FPAM_H= 37005.5, but got {exthdr['FPAM_H']}"
+        assert exthdr['FPAM_V'] == 22573, f"Expected data FPAM_V=22573, but got {exthdr['FPAM_V']}"
+        assert exthdr['FPAMNAME'] == 'SPC34_R2C2', f"Expected data FPAMNAME='SPC34_R2C2', but got {exthdr['FPAMNAME']}"
+        assert exthdr['FPAMSP_H'] ==  37005.5, f"Expected data FPAMSP_H= 37005.5, but got {exthdr['FPAMSP_H']}"
+        assert exthdr['FPAMSP_V'] == 22573, f"Expected data FPAMSP_V=22573, but got {exthdr['FPAMSP_V']}"
+
+        assert exthdr['FSAM_H'] ==  24087, f"Expected data FSAM_H=24087, but got {exthdr['FSAM_H']}"
+        assert exthdr['FSAM_V'] == 12238, f"Expected data FSAM_V=12238, but got {exthdr['FSAM_V']}"
+        assert exthdr['FSAMNAME'] == 'R1C2', f"Expected data FSAMNAME='R1C2', but got {exthdr['FSAMNAME']}"
+        assert exthdr['FSAMSP_H'] ==  24087, f"Expected data FSAMSP_H=24087, but got {exthdr['FSAMSP_H']}"
+        assert exthdr['FSAMSP_V'] == 12238, f"Expected data FSAMSP_V=12238, but got {exthdr['FSAMSP_V']}"
+
+        ### delete file after testing
+        print('Deleted the FITS file after testing headers populated with default values')
+        os.remove(f)
+
+
+if __name__ == '__main__':
+    #run_sim()
+    test_L1_product_fits_format_specmode()
+


### PR DESCRIPTION
## Purpose  
Populate headers for spectroscopy mode simulations.  

## Summary of Changes  
**Major updates** in `instrument.py` and `outputs.py`:  

1. **Store spectroscopy parameters in HDU headers**  
   - Added spectroscopy parameters such as `"slit"` and `"prism"` to `sim_info` and `header_info` in `CorgiOptics` and `CorgiDetector`.  

2. **Populate L1 headers**  
   - Updated `output.py` to populate L1 headers for spectroscopy mode based on provided inputs. 
   - If optics_keyword['use_fpm'] is False, it means no focal plane mask is used and the simulation represents unocculted stars. In this case, I set FPAM_H = FPAM_V = FPAMSP_H = FPAMSP_V = -9999 and FPAMNAME = 'N/A'.
       

3. **Test unit**  
   - Added a test unit: `test_L1_product_fits_format_specmode.py`.  

4. **Items requiring clarification**  
   - In spectroscopy mode, there are options to not use the slit and/or prism.  
   - It is unclear how to populate the `DPAM` and `FSAM` headers in such cases, since these depend on the specific slit mask or prism used.  
   - Currently, an error message is raised if no slit or prism is provided for **spectroscopy mode + full-frame** L1 products.  
   - Simulations for spectroscopy mode without a slit or prism can still be run for **sub-frame** simulations, but not for formal **full-frame** L1 simulations.  
