### PR TITLE
remove outdated keyword integrate_pixels

### DIFF
--- a/examples/polarimetry_demo.ipynb
+++ b/examples/polarimetry_demo.ipynb
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "5c3889db",
    "metadata": {},
    "outputs": [
@@ -131,7 +131,7 @@
     "#initialize instrument and generate 0/90 PSF pair\n",
     "optics_keywords = {'cor_type':cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':output_dim, 'prism':prism,\\\n",
     "                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }\n",
-    "optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)\n",
+    "optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True)\n",
     "sim_scene = optics.get_host_star_psf(base_scene)\n",
     "image_star_corgi_horizontal = sim_scene.host_star_image.data[0]\n",
     "image_star_corgi_vertical = sim_scene.host_star_image.data[1]\n",
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "e5f70fdb",
    "metadata": {},
    "outputs": [
@@ -368,7 +368,7 @@
     "#generate 45/135 PSF pair\n",
     "optics_keywords = {'cor_type':cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':output_dim, 'prism':prism,\\\n",
     "                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }\n",
-    "optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)\n",
+    "optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True)\n",
     "sim_scene = optics.get_host_star_psf(base_scene)\n",
     "image_star_corgi_45 = sim_scene.host_star_image.data[0]\n",
     "image_star_corgi_135 = sim_scene.host_star_image.data[1]\n",
@@ -550,7 +550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "73c8a93b",
    "metadata": {},
    "outputs": [
@@ -566,7 +566,7 @@
     "#generate unpolarized image\n",
     "optics_keywords = {'cor_type':cor_type, 'use_errors':2, 'polaxis':polaxis, 'output_dim':output_dim, 'prism':prism,\\\n",
     "                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }\n",
-    "optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)\n",
+    "optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True)\n",
     "sim_scene = optics.get_host_star_psf(base_scene)\n",
     "image_star_corgi_unpol = sim_scene.host_star_image.data\n",
     "sim_scene = optics.inject_point_sources(base_scene, sim_scene)\n",

--- a/examples/spc-wide_demo.ipynb
+++ b/examples/spc-wide_demo.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "ad49a112",
    "metadata": {},
    "outputs": [
@@ -67,7 +67,7 @@
     "optics_keywords = {'cor_type':cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':201,\\\n",
     "                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }\n",
     "   \n",
-    "optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)\n",
+    "optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True)\n",
     "\n",
     "#generate host star psf\n",
     "sim_scene = optics.get_host_star_psf(base_scene)\n",

--- a/test/test_bandpass.py
+++ b/test/test_bandpass.py
@@ -33,7 +33,7 @@ def test_bandpass():
 
     optics_keywords ={'cor_type': cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':101,\
                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
-    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)
+    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)
     
     #print(optics.lam_um[1])
     #bp = optics.setup_bandpass(cgi_mode, bandpass, 0)

--- a/test/test_inputs.py
+++ b/test/test_inputs.py
@@ -179,7 +179,7 @@ def test_input_from_cpgs():
     scene_target, scene_reference, optics, detector_target, detector_reference, visit_list = inputs.load_cpgs_data(abs_path)
 
     scene_input = scene.Scene(input.host_star_properties)
-    optics_input =  instrument.CorgiOptics(input.cgi_mode, input.bandpass, optics_keywords=input.optics_keywords, if_quiet=True, integrate_pixels=True)
+    optics_input =  instrument.CorgiOptics(input.cgi_mode, input.bandpass, optics_keywords=input.optics_keywords, if_quiet=True)
     detector_input = instrument.CorgiDetector( input.emccd_keywords)
 
     # Check that the two methods return the same objects       

--- a/test/test_installation.py
+++ b/test/test_installation.py
@@ -48,7 +48,7 @@ def test_install():
     optics_keywords ={'cor_type':cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':201,\
                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
    
-    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)
+    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)
     assert isinstance(optics, instrument.CorgiOptics)
 
     sim_scene = optics.get_host_star_psf(base_scene)

--- a/test/test_minimal.py
+++ b/test/test_minimal.py
@@ -214,7 +214,7 @@ def test_spc_mode():
     optics_keywords = {'cor_type':cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':201,\
                     'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
 
-    optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)
+    optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True)
     sim_scene = optics.get_host_star_psf(base_scene)
     image_star_corgi = sim_scene.host_star_image.data
     polaxis_cgisim = -10

--- a/test/test_observation_sequence.py
+++ b/test/test_observation_sequence.py
@@ -26,7 +26,7 @@ def test_generate_observation_sequence():
     emccd_keywords ={'em_gain':gain}
 
     base_scene = scene.Scene(host_star_properties)
-    optics =  instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)
+    optics =  instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True)
     detector = instrument.CorgiDetector( emccd_keywords)
     
     exp_time = 2000

--- a/test/test_on_axis_star.py
+++ b/test/test_on_axis_star.py
@@ -37,7 +37,7 @@ def test_on_axis_star():
     optics_keywords ={'cor_type':cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':201,\
                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
     optics_keywords_copy = copy.deepcopy(optics_keywords)
-    optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)
+    optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True)
 
     efields = optics.get_e_field()
 

--- a/test/test_on_axis_star_on_dector_subframe.py
+++ b/test/test_on_axis_star_on_dector_subframe.py
@@ -41,7 +41,7 @@ def test_on_axis_star_on_detector_subframe():
     optics_keywords ={'cor_type':cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':201,\
                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
    
-    optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True, integrate_pixels=True)
+    optics = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, if_quiet=True)
     sim_scene = optics.get_host_star_psf(base_scene)
     image = sim_scene.host_star_image.data
     

--- a/test/test_polarimetry.py
+++ b/test/test_polarimetry.py
@@ -37,7 +37,7 @@ def test_polarimetry():
     #Generate 0/90 image pair
     optics_keywords_0_90 = {'cor_type':cor_type, 'use_errors':2, 'polaxis':-10, 'output_dim':output_dim, 'prism':'POL0',\
                     'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
-    optics_0_90 = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords_0_90, if_quiet=True, integrate_pixels=True)
+    optics_0_90 = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords_0_90, if_quiet=True)
     sim_scene_0_90 = optics_0_90.get_host_star_psf(base_scene)
     image_star_corgi_x = sim_scene_0_90.host_star_image.data[0]
     image_star_corgi_y = sim_scene_0_90.host_star_image.data[1]
@@ -48,7 +48,7 @@ def test_polarimetry():
     #Generate 45/135 image pair
     optics_keywords_45_135 = {'cor_type':cor_type, 'use_errors':2, 'polaxis':-10, 'output_dim':output_dim, 'prism':'POL45',\
                     'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
-    optics_45_135 = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords_45_135, if_quiet=True, integrate_pixels=True)
+    optics_45_135 = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords_45_135, if_quiet=True)
     sim_scene_45_135 = optics_45_135.get_host_star_psf(base_scene)
     image_star_corgi_45 = sim_scene_45_135.host_star_image.data[0]
     image_star_corgi_135 = sim_scene_45_135.host_star_image.data[1]
@@ -60,7 +60,7 @@ def test_polarimetry():
     #leave prism keyword blank to test that it autofills to None
     optics_keywords_unpol = {'cor_type':cor_type, 'use_errors':2, 'polaxis':-10, 'output_dim':output_dim,\
                     'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
-    optics_unpol = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords_unpol, if_quiet=True, integrate_pixels=True)
+    optics_unpol = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords_unpol, if_quiet=True)
     sim_scene_unpol = optics_unpol.get_host_star_psf(base_scene)
     image_star_corgi_unpol = sim_scene_unpol.host_star_image.data
     sim_scene_unpol = optics_unpol.inject_point_sources(base_scene, sim_scene_unpol)


### PR DESCRIPTION
remove outdated input keyword  `integrate_pixels ` for `corgisim.optics` in all test files and example tutorials. 