### PR TITLE
populate EACQ_COL and EACQ_ROW

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1129,7 +1129,8 @@ class CorgiDetector():
             header_info = {'EXPTIME': exptime,'EMGAIN_C':self.emccd_keywords_default['em_gain'],'PSFREF':ref_flag,
                            'PHTCNT':self.photon_counting,'KGAINPAR':self.emccd_keywords_default['e_per_dn'],'cor_type':sim_info['cor_type'], 'bandpass':sim_info['bandpass'],
                            'cgi_mode': sim_info['cgi_mode'], 'polaxis':sim_info['polaxis'],'use_fpm':use_fpm,'nd_filter':sim_info['nd_filter'], 'polarization_basis': sim_info['polarization_basis'],'SATSPOTS':sim_info['SATSPOTS'],
-                           'use_pupil_lens':use_pupil_lens,'use_lyot_stop':use_lyot_stop, 'use_field_stop':use_field_stop, 'ROLL': float(sim_info['roll_angle'])}
+                           'use_pupil_lens':use_pupil_lens,'use_lyot_stop':use_lyot_stop, 'use_field_stop':use_field_stop, 'ROLL': float(sim_info['roll_angle']),
+                           'EACQ_ROW': loc_x, 'EACQ_COL': loc_y}
             if 'fsm_x_offset_mas' in sim_info:
                 header_info['FSMX'] = float(sim_info['fsm_x_offset_mas'])
             if 'fsm_y_offset_mas' in sim_info:

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -69,6 +69,9 @@ def create_hdu_list(data, header_info, sim_info=None):
     exthdr['EMGAIN_C'] = header_info['EMGAIN_C']
     exthdr['EMGAIN_A'] = header_info['EMGAIN_C']  
     exthdr['KGAINPAR'] =  header_info['KGAINPAR']
+    exthdr['EACQ_ROW'] =  header_info['EACQ_ROW']
+    exthdr['EACQ_COL'] =  header_info['EACQ_COL']
+
     if header_info['PHTCNT'] == True:
         exthdr['ISPC']= int(1)
     else:

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -226,6 +226,8 @@ def test_L1_product_fits_format():
     assert exthdr['EMGAIN_C'] == gain, f"Expected data EMGAIN_C={gain}, but got {exthdr['EMGAIN_C']}"
     assert exthdr['EMGAIN_A'] == gain, f"Expected data EMGAIN_A={gain}, but got {exthdr['EMGAIN_A']}"
     assert exthdr['ISPC'] == 0, f"Expected header ISPC=0, but got {exthdr['ISPC']}"
+    assert exthdr['EACQ_ROW'] == 300, f"Expected header EACQ_ROW=300, but got {exthdr['EACQ_ROW']}"
+    assert exthdr['EACQ_COL'] == 300, f"Expected header EACQ_COL=300, but got {exthdr['EACQ_COL']}"
 
     ### delete file after testing
     print('Deleted the FITS file after testing headers populated with non-dafult values(inputs)')


### PR DESCRIPTION
## Purpose
Populate the EACQ_ROW and EACQ_COL headers. In CorgiDetector, the variables loc_x and loc_y define where the center of the image is placed on the detector. In regular mode, this corresponds to the coronagraph center. In polarization mode, however, the image is split into two by the Wollaston prism, and loc_x and loc_y represent the central location between the two images.

## Summary of Changes
**Major updates** to  `output.py` 

Pass the two varibal to populate the headers

