### PR TITLE
correct bug photon_counting

### DIFF
--- a/corgisim/inputs.py
+++ b/corgisim/inputs.py
@@ -358,7 +358,7 @@ def load_cpgs_data(filepath, return_input=False):
         scene_reference = scene.Scene(host_star_properties_reference)
 
     if (cpgs_input.find('target_autogain').text == '0'):
-        photon_counting = (cpgs_input.find('target_pcounting')=='1')
+        photon_counting = (cpgs_input.find('target_pcounting').text=='1')
         em_gain = float(cpgs_input.find('target_gain').text)
         # em_gain cannot be under 1 in emccd. Since it's possible to set it to less than 1 in CPGS for now, we overwrite it
         if em_gain < 1 : 
@@ -369,7 +369,7 @@ def load_cpgs_data(filepath, return_input=False):
 
     if reference_star_present :
         if (cpgs_input.find('reference_autogain').text == '0'):
-            photon_counting = (cpgs_input.find('reference_pcounting')=='1')
+            photon_counting = (cpgs_input.find('reference_pcounting').text=='1')
             em_gain = float(cpgs_input.find('reference_gain').text)
             # em_gain cannot be under 1 in emccd. Since it's possible to set it to less than 1 in CPGS for now, we overwrite it
             if em_gain < 1 : 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx == 8.2.3
 sphinx_rtd_theme
 nbsphinx
 pandoc

--- a/test/test_inputs.py
+++ b/test/test_inputs.py
@@ -43,6 +43,8 @@ def test_cpgs_loading():
     assert isinstance(optics, instrument.CorgiOptics)
     assert isinstance(visit_list, list)
     assert len(visit_list) > 0
+    assert detector_target.photon_counting == True
+    assert detector_reference.photon_counting == True
 
     sim_scene_target  = optics.get_host_star_psf(scene_target)
     sim_scene_reference  = optics.get_host_star_psf(scene_reference)

--- a/test/test_minimal.py
+++ b/test/test_minimal.py
@@ -177,6 +177,9 @@ def test_cpgs_obs():
     abs_path =  os.path.join(script_dir, filepath)
 
     scene_target, scene_reference, optics, detector_target, detector_reference, visit_list = inputs.load_cpgs_data(abs_path)
+
+    assert detector_target.photon_counting == True
+    
     len_list = 0 
     for visit in visit_list:
         len_list += visit['number_of_frames']


### PR DESCRIPTION
Corrects a bug in which the photon counting wasn't correctly parsed from cpgs files. 
Additionally, the latest sphinx release causes an import error while building the doc, so I added a version in the doc requirements 