### PR TITLE
change the roman preflight lib

### DIFF
--- a/.github/workflows/minimal_test.yml
+++ b/.github/workflows/minimal_test.yml
@@ -38,8 +38,8 @@ jobs:
         cd ..        
     - name: Download and install Roman preflight
       run: |
-        wget https://sourceforge.net/projects/cgisim/files/roman_preflight_proper_public_v2.0.1_python.zip && unzip roman_preflight_proper_public_v2.0.1_python.zip
-        cd roman_preflight_proper_public_v2.0.1_python/
+        git clone https://github.com/roman-corgi/cgisim_cpp.git  
+        cd cgisim_cpp/
         python -m pip install .
         cd ..        
     - name: Download and install CGISim


### PR DESCRIPTION
In minimal_test.yml, we were previously downloading Roman preflight v2.0.0, which now causes issues because John has updated the package to v2.0.1. Besides, we’re using a fork that includes the polaxis parameters (needed to model polarization aberrations on the ±45° output axes), I’ve switched the YAML to point to our forked repo instead.

That said, we still need to sync our fork with John’s v2.0.1 updates—with the new DM files.