### PR TITLE
Update requirements.txt to set python version and numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+python==3.12
 astropy
-numpy
+numpy==1.26.4
 scipy
 ipython
 pytest


### PR DESCRIPTION
cgisim needs numpy<2.0.0 (np.trapz->np.trapezoid) and corgisim & corgidrp require python 3.12 because of strings.