### PR TITLE
New ability to overwrite headers in the save_hdu function

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1225,8 +1225,9 @@ class CorgiOptics():
         sim_info['output_dim'] = self.optics_keywords['output_dim'] 
         sim_info['nd_filter'] = self.nd
         sim_info['roll_angle'] = self.roll_angle
-                            
-                # Define specific keys from self.optics_keywords to include in the header            
+        sim_info['ref_flag'] = input_scene.ref_flag
+
+        # Define specific keys from self.optics_keywords to include in the header
         keys_to_include_in_header = [ 'use_errors','polaxis','final_sampling_m', 'use_dm1','use_dm2','use_fpm',
                             'use_lyot_stop','use_field_stop','fsm_x_offset_mas','fsm_y_offset_mas','slit','prism',
                             'slit_x_offset_mas','slit_y_offset_mas','use_pupil_lens', 'use_lyot_stop', 'use_field_stop']  # Specify keys to include

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -142,7 +142,8 @@ def create_hdu(data, sim_info=None):
     return hdu
 
 
-def save_hdu_to_fits( hdul, outdir=None, overwrite=False, write_as_L1=False, filename=None):
+def save_hdu_to_fits( hdul, outdir=None, overwrite=False, write_as_L1=False, filename=None,
+                     overwrite_pri_keywords=None, overwrite_ext_keywords=None):
         """
         Save an Astropy HDUList to a FITS file.
 
@@ -180,10 +181,27 @@ def save_hdu_to_fits( hdul, outdir=None, overwrite=False, write_as_L1=False, fil
 
         # Construct full file path
         filepath = os.path.join(outdir, filename)
+
+        overwrite_pri_keys = overwrite_pri_keywords.keys() if overwrite_pri_keywords else []
+        overwrite_ext_keys = overwrite_ext_keywords.keys() if overwrite_ext_keywords else []
+
+        for key in overwrite_pri_keys:
+            if key in hdul[0].header:
+                hdul[0].header[key] = overwrite_pri_keywords[key]
+            else:
+                raise KeyError(f"Primary header keyword '{key}' not found in HDUList.")
         
+        for key in overwrite_ext_keys:
+            if key in hdul[1].header:
+                hdul[1].header[key] = overwrite_ext_keywords[key]
+            else:
+                raise KeyError(f"Extension header keyword '{key}' not found in HDUList.")
+
         # Write the HDUList to file
         hdul.writeto(filepath, overwrite=overwrite)
         print(f"Saved FITS file to: {filepath}")
+    
+        return filepath
 
 
 def isotime_to_yyyymmddThhmmsss(timestr):

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -73,7 +73,6 @@ def test_L1_product_fits_format():
     time_in_name = outputs.isotime_to_yyyymmddThhmmsss(exthdr['FTIMEUTC'])
     filename = f"cgi_{prihdr['VISITID']}_{time_in_name}_l1_.fits"
 
-
     f = os.path.join( outdir , filename)
  
     with fits.open(f) as hdul:
@@ -142,6 +141,28 @@ def test_L1_product_fits_format():
 
     ### delete file after testing
     print('Deleted the FITS file after testing headers populated with default values')
+    os.remove(f)
+
+
+        ### Test overwrite_pri_hdr and overwrite_ext_hdr with non-default values
+    outputs.save_hdu_to_fits(sim_scene.image_on_detector,outdir=outdir, write_as_L1=True, 
+                             overwrite_pri_keywords={'TARGET':'HD 141569A'}, 
+                             overwrite_ext_keywords={'OPMODE': "Disco"},
+                             )
+    #Open the file and check the new values in the headers
+    time_in_name = outputs.isotime_to_yyyymmddThhmmsss(exthdr['FTIMEUTC'])
+    filename = f"cgi_{prihdr['VISITID']}_{time_in_name}_l1_.fits"
+
+    f = os.path.join( outdir , filename)
+    with fits.open(f) as hdul:
+        prihr = hdul[0].header
+        exthr = hdul[1].header
+
+        assert prihr['TARGET'] == 'HD 141569A', f"Expected header TARGET=HD 141569A, but got {prihr['TARGET']}"
+        assert exthr['OPMODE'] == "Disco", f"Expected header OPMODE=Disco, but got {exthr['OPMODE']}"
+
+    ### delete file after testing
+    print('Deleted the FITS file after testing overwrite_pri_hdr and overwrite_ext_hdr with non-default values')
     os.remove(f)
 
     ####################################################################################################


### PR DESCRIPTION
The PR implements the ability to overwrite header keywords in the primary or extension HDUs at the time of saving the file to fits. A test is included. 

There's also a minor fix that makes sure we propagate the ref flag even if we're only including an off-axis source. 