### PR TITLE
Header update: Replace ROLL with PA_APER

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1441,7 +1441,7 @@ class CorgiDetector():
             header_info = {'EXPTIME': exptime,'EMGAIN_C':self.emccd_keywords_default['em_gain'],'PSFREF':ref_flag,
                            'PHTCNT':self.photon_counting,'KGAINPAR':self.emccd_keywords_default['e_per_dn'],'cor_type':sim_info['cor_type'], 'bandpass':sim_info['bandpass'],
                            'cgi_mode': sim_info['cgi_mode'], 'polaxis':sim_info['polaxis'],'use_fpm':use_fpm,'nd_filter':sim_info['nd_filter'], 'polarization_basis': sim_info['polarization_basis'],'SATSPOTS':sim_info['SATSPOTS'],
-                           'use_pupil_lens':use_pupil_lens,'use_lyot_stop':use_lyot_stop, 'use_field_stop':use_field_stop, 'ROLL': float(sim_info['roll_angle']),
+                           'use_pupil_lens':use_pupil_lens,'use_lyot_stop':use_lyot_stop, 'use_field_stop':use_field_stop, 'PA_APER': float(sim_info['roll_angle']),
                            'EACQ_ROW': loc_x, 'EACQ_COL': loc_y,'RN': self.emccd_keywords_default['read_noise']}
             if 'fsm_x_offset_mas' in sim_info:
                 header_info['FSMX'] = float(sim_info['fsm_x_offset_mas'])

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -50,7 +50,7 @@ def create_hdu_list(data, header_info, sim_info=None):
     ### currently we don't have sequence smulation, so the time per frame == exposure time
     ### it needs to be updated later
     prihdr['FRAMET'] = header_info['EXPTIME']
-    prihdr['ROLL'] = header_info['ROLL']
+    prihdr['PA_APER'] = header_info['PA_APER']
 
     ### wait this for tachi to add sattlite spots function
     #prihdr['SATSPOTS'] = header_info['SATSPOTS'] 

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -167,7 +167,7 @@ def test_L1_product_fits_format():
     os.remove(f)
 
     ####################################################################################################
-    #### testing the non-defalut(input) value pass to header
+    #### testing the non-default(input) value pass to header
     Vmag = 8
     sptype = 'G0V'
     cgi_mode = 'excam'
@@ -246,7 +246,8 @@ def test_L1_product_fits_format():
     assert prihr['PSFREF'] == True, f"Expected header PSFREF=False, but got {prihr['PSFREF']}"
     assert prihr['PHTCNT'] == False, f"Expected header PSFREF=False, but got {prihr['PHTCNT']}"
     assert prihdr['FRAMET'] == exptime, f"Expected header FRAMET = {exptime}, but got {prihdr['FRAMET']}"
-    assert prihr['ROLL'] == 10.0, f"Expected data ROLL=10, but got {prihr['ROLL']}"
+    assert prihr['ROLL'] == 0.0, f"Expected data ROLL=0, but got {prihr['ROLL']}"
+    assert prihr['PA_APER'] == roll_angle, f"Expected data ROLL={roll_angle}, but got {prihr['PA_APER']}"
 
     assert exthdr['KGAINPAR'] == e_per_dn, f"Expected data KGAINPAR={e_per_dn}, but got {exthdr['KGAINPAR']}"
     assert exthdr['EMGAIN_C'] == gain, f"Expected data EMGAIN_C={gain}, but got {exthdr['EMGAIN_C']}"

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -91,6 +91,7 @@ def test_L1_product_fits_format():
     assert prihr['PSFREF'] == False, f"Expected data PSFREF=False, but got {prihr['PSFREF']}"
     assert prihr['PHTCNT'] == True, f"Expected data PSFREF=True, but got {prihr['PHTCNT']}"
     assert prihr['ROLL'] == 0.0, f"Expected data ROLL=0, but got {prihr['ROLL']}"
+    assert prihr['PA_APER'] == 0.0, f"Expected data PA_APER=0, but got {prihr['PA_APER']}"
 
     assert exthdr['SATSPOTS'] == 0, f"Expected data SATSPOTS=0, but got {exthdr['SATSPOTS']}"
     assert exthdr['KGAINPAR'] == 8.7, f"Expected data KGAINPAR=8.7, but got {exthdr['KGAINPAR']}"
@@ -247,7 +248,7 @@ def test_L1_product_fits_format():
     assert prihr['PHTCNT'] == False, f"Expected header PSFREF=False, but got {prihr['PHTCNT']}"
     assert prihdr['FRAMET'] == exptime, f"Expected header FRAMET = {exptime}, but got {prihdr['FRAMET']}"
     assert prihr['ROLL'] == 0.0, f"Expected data ROLL=0, but got {prihr['ROLL']}"
-    assert prihr['PA_APER'] == roll_angle, f"Expected data ROLL={roll_angle}, but got {prihr['PA_APER']}"
+    assert prihr['PA_APER'] == roll_angle, f"Expected data PA_APER={roll_angle}, but got {prihr['PA_APER']}"
 
     assert exthdr['KGAINPAR'] == e_per_dn, f"Expected data KGAINPAR={e_per_dn}, but got {exthdr['KGAINPAR']}"
     assert exthdr['EMGAIN_C'] == gain, f"Expected data EMGAIN_C={gain}, but got {exthdr['EMGAIN_C']}"
@@ -392,7 +393,7 @@ def test_L1_product_from_CPGS():
 
             f = os.path.join( outdir , filename)
             assert os.path.isfile(f)
-            assert prihdr['ROLL'] == visit["roll_angle"]
+            assert prihdr['PA_APER'] == visit["roll_angle"]
             i += 1
     # Delete the files 
     shutil.rmtree(outdir)


### PR DESCRIPTION
## Describe your changes and reference any relevant issues (don't forget the #)
For consistency with the DRP, this PR replaces 'ROLL' in the prihdr with 'PA_APER'. Without this change, the DRP does not recognize roll angles correctly, so datasets containing multiple rolls lead to an L4 image with multiple copies of the companion(s).
This PR addresses Issue #205. 

## Checklist before requesting a review
- [X ] I have verified that test_minimal.py passes and I have added a test there if appropriate.

## Checklist before merging
- [ ] I have checked the complete tests pass on that branch (check the Github Actions tab)
