### PR TITLE
Realistic MJDSRT and MJDEND

### DIFF
--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -67,10 +67,6 @@ def create_hdu_list(data, header_info, sim_info=None):
     exthdr['NAXIS1'] = data.shape[0]
     exthdr['NAXIS2'] = data.shape[1]
     exthdr['EXPTIME'] = header_info['EXPTIME']
-    # Calculate MJDSRT and MJDEND from FTIMEUTC timestamp and EXPTIME
-    mjd_start = Time(exthdr['FTIMEUTC']).mjd
-    exthdr['MJDSRT'] = mjd_start
-    exthdr['MJDEND'] = mjd_start + exthdr['EXPTIME'] / 86400.0
     exthdr['EMGAIN_C'] = header_info['EMGAIN_C']
     exthdr['EMGAIN_A'] = header_info['EMGAIN_C']  
     exthdr['KGAINPAR'] =  header_info['KGAINPAR']
@@ -201,6 +197,11 @@ def save_hdu_to_fits( hdul, outdir=None, overwrite=False, write_as_L1=False, fil
                 hdul[1].header[key] = overwrite_ext_keywords[key]
             else:
                 raise KeyError(f"Extension header keyword '{key}' not found in HDUList.")
+
+        # Calculate MJDSRT and MJDEND from FTIMEUTC timestamp and EXPTIME
+        mjd_start = Time(hdul[1].header['FTIMEUTC']).mjd
+        hdul[1].header['MJDSRT'] = mjd_start
+        hdul[1].header['MJDEND'] = mjd_start + hdul[1].header['EXPTIME'] / 86400.0
 
         # Write the HDUList to file
         hdul.writeto(filepath, overwrite=overwrite)

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -1,4 +1,5 @@
 from astropy.io import fits
+from astropy.time import Time
 from corgidrp import mocks
 import os
 from datetime import datetime, timezone, timedelta
@@ -66,6 +67,10 @@ def create_hdu_list(data, header_info, sim_info=None):
     exthdr['NAXIS1'] = data.shape[0]
     exthdr['NAXIS2'] = data.shape[1]
     exthdr['EXPTIME'] = header_info['EXPTIME']
+    # Calculate MJDSRT and MJDEND from FTIMEUTC timestamp and EXPTIME
+    mjd_start = Time(exthdr['FTIMEUTC']).mjd
+    exthdr['MJDSRT'] = mjd_start
+    exthdr['MJDEND'] = mjd_start + exthdr['EXPTIME'] / 86400.0
     exthdr['EMGAIN_C'] = header_info['EMGAIN_C']
     exthdr['EMGAIN_A'] = header_info['EMGAIN_C']  
     exthdr['KGAINPAR'] =  header_info['KGAINPAR']

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -146,22 +146,25 @@ def test_L1_product_fits_format():
     os.remove(f)
 
 
-        ### Test overwrite_pri_hdr and overwrite_ext_hdr with non-default values
-    outputs.save_hdu_to_fits(sim_scene.image_on_detector,outdir=outdir, write_as_L1=True, 
-                             overwrite_pri_keywords={'TARGET':'HD 141569A'}, 
-                             overwrite_ext_keywords={'OPMODE': "Disco"},
+        ### Test overwrite_pri_hdr and overwrite_ext_hdr with non-default values including FTIMEUTC and MJDSRT
+    outputs.save_hdu_to_fits(sim_scene.image_on_detector,outdir=outdir, write_as_L1=True,
+                             overwrite_pri_keywords={'TARGET':'HD 141569A'},
+                             overwrite_ext_keywords={'OPMODE': "Disco", 'FTIMEUTC': '2025-01-01T00:00:00'},
                              )
     #Open the file and check the new values in the headers
-    time_in_name = outputs.isotime_to_yyyymmddThhmmsss(exthdr['FTIMEUTC'])
-    filename = f"cgi_{prihdr['VISITID']}_{time_in_name}_l1_.fits"
+    # Find the most recently created file (filename uses current timestamp, not overridden FTIMEUTC)
+    import glob
+    files = glob.glob(os.path.join(outdir, 'cgi_*_l1_.fits'))
+    f = max(files, key=os.path.getmtime)
 
-    f = os.path.join( outdir , filename)
     with fits.open(f) as hdul:
         prihr = hdul[0].header
         exthr = hdul[1].header
 
         assert prihr['TARGET'] == 'HD 141569A', f"Expected header TARGET=HD 141569A, but got {prihr['TARGET']}"
         assert exthr['OPMODE'] == "Disco", f"Expected header OPMODE=Disco, but got {exthr['OPMODE']}"
+        # Check that MJDSRT was correctly calculated from the overridden FTIMEUTC (2025-01-01T00:00:00 = MJD 60676.0)
+        assert exthr['MJDSRT'] == 60676.0, f"Expected header MJDSRT=60676.0 (from overridden FTIMEUTC), but got {exthr['MJDSRT']}"
 
     ### delete file after testing
     print('Deleted the FITS file after testing overwrite_pri_hdr and overwrite_ext_hdr with non-default values')

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -9,6 +9,7 @@ import roman_preflight_proper
 import pytest
 import cgisim
 import os, shutil
+import glob
 
 def test_L1_product_fits_format():
     """Test the headers of saved L1 product FITS file
@@ -153,7 +154,6 @@ def test_L1_product_fits_format():
                              )
     #Open the file and check the new values in the headers
     # Find the most recently created file (filename uses current timestamp, not overridden FTIMEUTC)
-    import glob
     files = glob.glob(os.path.join(outdir, 'cgi_*_l1_.fits'))
     f = max(files, key=os.path.getmtime)
 


### PR DESCRIPTION
## Describe your changes and reference any relevant issues (don't forget the #)
Updates outputs.py so that MJDSRT is set to the Julian date equivalent of the value that is in FTIMEUTC. MJDEND = MJDSRT + (Julian date equivalent of exposure time).

This was done in response to corgidrp issue 853: https://github.com/roman-corgi/corgidrp/issues/853 but was determined corgisim would be a better place for this fix.

## Checklist before requesting a review
- [ ] I have verified that test_minimal.py passes and I have added a test there if appropriate.

## Checklist before merging
- [ ] I have checked the complete tests pass on that branch (check the Github Actions tab)
