### PR TITLE
add target and vistype for header

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -53,6 +53,13 @@ class CorgiOptics():
             - roll_angle : float, optional, Telescope roll angle in degrees (0 to 360). 
                            Defined as the rotation angle of the excam coordinates (X, Y) relative to the sky coordinates(RA,DEC), positive is counter-clockwise.
                            Default is 0 degrees, corresponding to North up, East left in the sky coordinates.
+            **kwargs:
+            Additional optional keyword arguments.Supported options include:
+            - visit_type (str, optional): A string indicating the type of visit (e.g.CGIVST_CAL_TGTREF_PHOT) for populating header VISTYPE.
+            - if_quiet (bool, optional): If True, suppresses print statements during optics initialization. 
+
+              
+            
         Raises:
             - ValueError: If `cgi_mode` or `cor_type` is invalid.
             - KeyError: If required `optics_keywords` are missing.
@@ -294,6 +301,7 @@ class CorgiOptics():
 
 
         if 'if_quiet'in kwargs:self.quiet = kwargs.get("if_quiet")
+        self.visit_type = kwargs.get("visit_type", "CGIVST_TDD_OBS")
 
         ##self.SATSPOTS is the value to be populated to L1 header prihdr[SATSPOTS]
         # prihdr[SATSPOTS]= 0: No satellite spots present 
@@ -882,7 +890,9 @@ class CorgiOptics():
                     'over_sampling_factor':self.oversampling_factor,
                     'return_oversample': self.return_oversample,
                     'output_dim': self.optics_keywords['output_dim'],
-                    'nd_filter':self.nd}
+                    'nd_filter':self.nd,
+                    'target_name': input_scene.target_name,
+                    'visit_type': self.visit_type}
 
         # Define specific keys from self.optics_keywords to include in the header            
         keys_to_include_in_header = ['use_errors','polaxis','final_sampling_m', 'use_dm1','use_dm2','use_fpm',
@@ -1442,7 +1452,7 @@ class CorgiDetector():
                            'PHTCNT':self.photon_counting,'KGAINPAR':self.emccd_keywords_default['e_per_dn'],'cor_type':sim_info['cor_type'], 'bandpass':sim_info['bandpass'],
                            'cgi_mode': sim_info['cgi_mode'], 'polaxis':sim_info['polaxis'],'use_fpm':use_fpm,'nd_filter':sim_info['nd_filter'], 'polarization_basis': sim_info['polarization_basis'],'SATSPOTS':sim_info['SATSPOTS'],
                            'use_pupil_lens':use_pupil_lens,'use_lyot_stop':use_lyot_stop, 'use_field_stop':use_field_stop, 'PA_APER': float(sim_info['roll_angle']),
-                           'EACQ_ROW': loc_x, 'EACQ_COL': loc_y,'RN': self.emccd_keywords_default['read_noise']}
+                           'EACQ_ROW': loc_x, 'EACQ_COL': loc_y,'RN': self.emccd_keywords_default['read_noise'],'target_name': sim_info['target_name'],'VISTYPE': sim_info['visit_type']}
             if 'fsm_x_offset_mas' in sim_info:
                 header_info['FSMX'] = float(sim_info['fsm_x_offset_mas'])
             if 'fsm_y_offset_mas' in sim_info:

--- a/corgisim/observation.py
+++ b/corgisim/observation.py
@@ -31,7 +31,7 @@ def generate_observation_sequence(scene, optics, detector, exp_time, n_frames, s
             x-coordinate of the full frame's origin (top-left pixel). Required if `full_frame` is True.
         loc_y (int, optional): The y-coordinate for the center of the sub-array in pixels
             if `full_frame` is False. If `full_frame` is True, this specifies the
-            y-coordinate of the full frame's origin (top-left pixel). Required if `full_frame` is True.
+            y-coordinate of the full frame's origin (top-left pixel). Required if `full_frame` is True.        
 
     Returns:
         list[corgisim.scene.SimulatedImage]: A list of :py:class:`corgisim.scene.SimulatedImage` objects,

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -42,6 +42,10 @@ def create_hdu_list(data, header_info, sim_info=None):
     prihdr['TELESCOP'] = 'ROMAN'
     prihdr['PSFREF'] = header_info['PSFREF']
     prihdr['OPGAIN'] = header_info['EMGAIN_C']
+    
+    prihdr['TARGET'] = header_info['target_name']
+    prihdr['VISTYPE'] = header_info['VISTYPE'] 
+    
     if header_info['PHTCNT'] == True:
         prihdr['PHTCNT'] =int(1)
     else:

--- a/corgisim/scene.py
+++ b/corgisim/scene.py
@@ -39,6 +39,7 @@ class Scene():
                 'ABmag' for AB magnitude system
             - "ref_flag" (boolean):optional, whether the input scene is a reference star (True) or a science target (False). Default is false
             - "stellar_diam_mas" (float): The stellar diameter of the host star in mas.
+            - "target_name" (str): optional, the name of the target star, used for headers. Default is UNKNOWN.
 
         point_sources_info (list): A list of dictionaries, each representing an off-axis point source in the scene. Each dictionary must contain:
             - "Vmag" (float): The apparent V-band magnitude of the source.
@@ -86,7 +87,8 @@ class Scene():
 
             # Set the reference flag from host_star_properties, defaulting to False if not provided
             self.ref_flag = host_star_properties_internal.get('ref_flag', False)
-            
+            self.target_name = host_star_properties_internal.get('target_name', "UNKNOWN")
+
             ### Retrieve the stellar spectrum based on spectral type and V-band magnitude
             ### The self.stellar_spectrum attribute is an instance of the SourceSpectrum class (from synphot), 
             ### used to store and retrieve the wavelength and stellar flux.

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -428,4 +428,4 @@ def test_L1_product_from_CPGS():
 if __name__ == '__main__':
     #run_sim()
     test_L1_product_fits_format()
-    #test_L1_product_from_CPGS()
+    test_L1_product_from_CPGS()

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -92,6 +92,8 @@ def test_L1_product_fits_format():
     assert prihr['PHTCNT'] == True, f"Expected data PSFREF=True, but got {prihr['PHTCNT']}"
     assert prihr['ROLL'] == 0.0, f"Expected data ROLL=0, but got {prihr['ROLL']}"
     assert prihr['PA_APER'] == 0.0, f"Expected data PA_APER=0, but got {prihr['PA_APER']}"
+    assert prihr['TARGET'] == 'UNKNOWN', f"Expected header TARGET = 'UNKNOWN', but got {prihr['TARGET']}"
+    assert prihr['VISTYPE'] == 'CGIVST_TDD_OBS', f"Expected header VISTYPE = 'CGIVST_TDD_OBS', but got {prihr['VISTYPE']}"
 
     assert exthdr['SATSPOTS'] == 0, f"Expected data SATSPOTS=0, but got {exthdr['SATSPOTS']}"
     assert exthdr['KGAINPAR'] == 8.7, f"Expected data KGAINPAR=8.7, but got {exthdr['KGAINPAR']}"
@@ -185,7 +187,7 @@ def test_L1_product_fits_format():
     info_dir = cgisim.lib_dir + '/cgisim_info_dir/'
 
     #Define the host star properties
-    host_star_properties = {'Vmag': Vmag, 'spectral_type': sptype, 'magtype': 'vegamag','ref_flag':True}
+    host_star_properties = {'Vmag': Vmag, 'spectral_type': sptype, 'magtype': 'vegamag','ref_flag':True,'target_name':'HD 141569A'}
     point_source_info = [{'Vmag': mag_companion[0], 'magtype': 'vegamag','position_x':dx[0] , 'position_y':dy[0]},
                          {'Vmag': mag_companion[1], 'magtype': 'vegamag','position_x':dx[1] , 'position_y':dy[1]}]
 
@@ -205,7 +207,7 @@ def test_L1_product_fits_format():
                 ##pass fsm_x_offset_mas and fsm_y_offset_mas for no zero value as test
 
     roll_angle=10.0 ##degree
-    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True, roll_angle=roll_angle)
+    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True, roll_angle=roll_angle, visit_type='CGIVST_CAL_TGTREF_PHOT')
     sim_scene = optics.get_host_star_psf(base_scene)
 
     sim_scene = optics.inject_point_sources(base_scene,sim_scene)
@@ -249,6 +251,8 @@ def test_L1_product_fits_format():
     assert prihdr['FRAMET'] == exptime, f"Expected header FRAMET = {exptime}, but got {prihdr['FRAMET']}"
     assert prihr['ROLL'] == 0.0, f"Expected data ROLL=0, but got {prihr['ROLL']}"
     assert prihr['PA_APER'] == roll_angle, f"Expected data PA_APER={roll_angle}, but got {prihr['PA_APER']}"
+    assert prihr['TARGET'] == 'HD 141569A', f"Expected header TARGET = 'HD 141569A', but got {prihr['TARGET']}"
+    assert prihr['VISTYPE'] == 'CGIVST_CAL_TGTREF_PHOT', f"Expected header VISTYPE = 'CGIVST_CAL_TGTREF_PHOT', but got {prihr['VISTYPE']}"
 
     assert exthdr['KGAINPAR'] == e_per_dn, f"Expected data KGAINPAR={e_per_dn}, but got {exthdr['KGAINPAR']}"
     assert exthdr['EMGAIN_C'] == gain, f"Expected data EMGAIN_C={gain}, but got {exthdr['EMGAIN_C']}"
@@ -424,4 +428,4 @@ def test_L1_product_from_CPGS():
 if __name__ == '__main__':
     #run_sim()
     test_L1_product_fits_format()
-    test_L1_product_from_CPGS()
+    #test_L1_product_from_CPGS()


### PR DESCRIPTION
In this PR, I added an optional target_name input attribute to the Scene class and an optional visit_type keyword to the Optics class. These two parameters are intended to populate the headers prihdr['TARGET'] and prihdr['VISTYPE'] with user-provided values. It avoid manually changing headers in output.py. 

