### PR TITLE
disable the simultaneous use of focal plane mask with certain nd filters

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -269,8 +269,6 @@ class CorgiOptics():
             if (optics_keywords_internal['use_fpm']==1) or (optics_keywords_internal['use_lyot_stop']==1) or (optics_keywords_internal['use_field_stop']==1):
                  warnings.warn('Warning: the pupil lens is inserted while one or more of the focal mask, Lyot stop, or field stop are also in use.', UserWarning)
 
-
-        # polarization
         
         if optics_keywords_internal['polaxis'] != 10 and optics_keywords_internal['polaxis'] != -10 and optics_keywords_internal['polaxis'] != 0:
             # wollaston transmission is around 0.96%, divide by two to split between polarization
@@ -299,6 +297,12 @@ class CorgiOptics():
                 self.nd = 0
             else:
                 raise ValueError(f"Invalid ND filter value: {optics_keywords['nd']}. Must be 0, 1, 2, or 3.")
+        
+        if optics_keywords_internal['use_fpm'] == 1 and (self.nd == 1 or self.nd == 2): 
+            raise ValueError( "FPM cannot be used with ND filter 1 (225@FPAM) or ND filter 2 (475@FPAM), because they occupy the same position in the optical path.")
+        if optics_keywords_internal['use_lyot_stop'] == 1 and  self.nd == 3:
+            raise ValueError( "Lyot stop cannot be used with ND filter 3 (475@FSAM), because they occupy the same position in the optical path.")
+        # polarization
             
         # Initialize the bandpass class (from synphot)
         # bp: wavelegth is in unit of angstrom

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -297,10 +297,10 @@ class CorgiOptics():
                 self.nd = 0
             else:
                 raise ValueError(f"Invalid ND filter value: {optics_keywords['nd']}. Must be 0, 1, 2, or 3.")
-        
-        if optics_keywords_internal['use_fpm'] == 1 and (self.nd == 1 or self.nd == 2): 
+
+        if optics_keywords_internal['use_fpm'] == 1 and (self.nd == '2.25' or self.nd == '4.75fpam'): 
             raise ValueError( "FPM cannot be used with ND filter 1 (225@FPAM) or ND filter 2 (475@FPAM), because they occupy the same position in the optical path.")
-        if optics_keywords_internal['use_lyot_stop'] == 1 and  self.nd == 3:
+        if optics_keywords_internal['use_lyot_stop'] == 1 and  self.nd == '4.75fsam':
             raise ValueError( "Lyot stop cannot be used with ND filter 3 (475@FSAM), because they occupy the same position in the optical path.")
         # polarization
             

--- a/examples/tutorial1_corgisim.ipynb
+++ b/examples/tutorial1_corgisim.ipynb
@@ -476,11 +476,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'optics' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 7\u001b[0m\n\u001b[1;32m      1\u001b[0m nd_filter \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m0\u001b[39m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;66;03m##options for nd_filter:\u001b[39;00m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;66;03m##nd_filter = 1: ND 2.25 @ FPAM\u001b[39;00m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;66;03m##nd_filter = 2: ND 4.75 @ FPAM\u001b[39;00m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;66;03m##nd_filter = 3: ND 4.75 @ FSAM\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;66;03m#bp = optics.setup_bandpass(cgi_mode, bandpass, nd_filter )\u001b[39;00m\n\u001b[0;32m----> 7\u001b[0m \u001b[43moptics\u001b[49m\u001b[38;5;241m.\u001b[39mbp\u001b[38;5;241m.\u001b[39mplot()\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'optics' is not defined"
+     ]
+    }
+   ],
    "source": [
     "nd_filter = 0\n",
+    "##options for nd_filter:\n",
+    "##nd_filter = 1: ND 2.25 @ FPAM\n",
+    "##nd_filter = 2: ND 4.75 @ FPAM\n",
+    "##nd_filter = 3: ND 4.75 @ FSAM\n",
+    "\n",
     "#bp = optics.setup_bandpass(cgi_mode, bandpass, nd_filter )\n",
     "optics.bp.plot()"
    ]

--- a/test/test_bandpass.py
+++ b/test/test_bandpass.py
@@ -8,7 +8,7 @@ import roman_preflight_proper
 import pytest
 import cgisim
 from synphot import units, SourceSpectrum, SpectralElement, Observation
-
+import re
 
 
 #@pytest.mark.parametrize("interp_method", ['linear', 'cubic'])
@@ -35,18 +35,36 @@ def test_bandpass():
                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
     optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)
     
-    #print(optics.lam_um[1])
-    #bp = optics.setup_bandpass(cgi_mode, bandpass, 0)
-  
-    #print(bp.avgwave(), bp.tlambda(), bp.efficiency(), bp.tpeak(),bp.wpeak())
-    #print(bp.equivwidth())
+### test the disable use of ND filter with FPM/FSM teh same time
+def test_nd_filter_FPM_conflicts():
+    host_star_properties = {'Vmag': 0.6, 'spectral_type': 'A0V','magtype': 'vegamag'}
     
-    #sp_rn.plot()
-    #optics.bp.plot()
- 
-    #plt.show()
+    #Create a Scene object that holds all this information
+    base_scene = scene.Scene(host_star_properties)
+    cgi_mode = 'excam'
+    cor_type = 'hlc'
+    bandpass = '1A'
+    cases = ['3e-8']       
+    rootname = 'hlc_ni_' + cases[0]
+    dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
+    dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
+
+    optics_keywords ={'cor_type': cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':51,\
+                       'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,\
+                        'use_field_stop':1, 'nd':1 }
+    msg1 = "FPM cannot be used with ND filter 1 (225@FPAM) or ND filter 2 (475@FPAM), because they occupy the same position in the optical path."
+    with pytest.raises(ValueError, match=re.escape(msg1)):
+        instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)
+    
+    msg2 = "Lyot stop cannot be used with ND filter 3 (475@FSAM), because they occupy the same position in the optical path."
+    optics_keywords2 ={'cor_type': cor_type, 'use_errors':2, 'polaxis':10, 'output_dim':51,\
+                       'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,\
+                        'use_field_stop':1, 'nd':3, }
+    with pytest.raises(ValueError, match=re.escape(msg2)):
+        instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords2, if_quiet=True)
   
   
     
 if __name__ == '__main__':
     test_bandpass()
+    test_nd_filter_FPM_conflicts()


### PR DESCRIPTION
There are three ND filter options:

self.nd = 1: ND 2.25 @ FPAM
self.nd = 2: ND 4.75 @ FPAM
self.nd = 3: ND 4.75 @ FSAM

This PR disables the simultaneous use of ND filters 1 or 2 with the focal plane mask, since they occupy the same position in the optical path.

It also disables the simultaneous use of ND filter 3 with the Lyot stop.

