### PR TITLE
updated FPAM and FSAM positions

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1360,13 +1360,13 @@ class CorgiOptics():
 
 class CorgiDetector(): 
     
-    def __init__(self ,emccd_keywords, photon_counting = True):
+    def __init__(self ,emccd_keywords, photon_counting = False):
         '''
         Initialize the class with a dictionary that defines the EMCCD_DETECT input parameters. 
 
         Arguments: 
             - emccd_keywords: A dictionary with the keywords that are used to set up the emccd model
-            - photon_counting: if use photon_counting mode, default is True
+            - photon_counting: if use photon_counting mode, default is False
         '''
         if emccd_keywords is None:
             self.emccd_keywords = None

--- a/corgisim/outputs.py
+++ b/corgisim/outputs.py
@@ -106,7 +106,7 @@ def create_hdu_list(data, header_info, sim_info=None):
     
     ##### need to update later
     exthdr['FPAM_H'], exthdr['FPAM_V'], exthdr['FPAMNAME'], exthdr['FPAMSP_H'],exthdr['FPAMSP_V'] = write_headers_FPAM(header_info['cor_type'], header_info['bandpass'], header_info['use_fpm'], header_info['nd_filter'])
-    exthdr['FSAM_H'], exthdr['FSAM_V'], exthdr['FSAMNAME'], exthdr['FSAMSP_H'],exthdr['FSAMSP_V'] = write_headers_FSAM(header_info['cor_type'], header_info['bandpass'], header_info['slit'], header_info['polaxis'], header_info['use_field_stop'])
+    exthdr['FSAM_H'], exthdr['FSAM_V'], exthdr['FSAMNAME'], exthdr['FSAMSP_H'],exthdr['FSAMSP_V'] = write_headers_FSAM(header_info['cor_type'], header_info['bandpass'], header_info['slit'], header_info['polarization_basis'], header_info['use_field_stop'])
 
 
 
@@ -545,11 +545,11 @@ def write_headers_FPAM(cor_type, band_pass,use_fpm,nd_filter):
         if 'hlc' in cor_type:
             ##hlc NFOV imaging mode
             if '1' in band_pass:
-                FPAM_H = 6757.2
-                FPAM_V = 22424
-                FPAMNAME = 'HLC12_C2R1'
-                FPAMSP_H = 6757.2
-                FPAMSP_V = 22424
+                FPAM_H = 6776
+                FPAM_V = 27653.3
+                FPAMNAME = 'HLC12_C2R5'
+                FPAMSP_H = 6776
+                FPAMSP_V = 27653.3
             
             if '2' in band_pass:
                 FPAM_H = 55306.4
@@ -575,11 +575,11 @@ def write_headers_FPAM(cor_type, band_pass,use_fpm,nd_filter):
         if 'wide' in cor_type:
             ##spc WFOV imaging mode
             if '1' in band_pass:
-                FPAM_H = 23719.6
-                FPAM_V = 2278.1
-                FPAMNAME = 'SPC12_R1C1'
-                FPAMSP_H = 23719.6
-                FPAMSP_V = 2278.1
+                FPAM_H = 18751
+                FPAM_V = 4621.9
+                FPAMNAME = 'SPC12_R2C1'
+                FPAMSP_H = 18751
+                FPAMSP_V = 4621.9
 
             if '4' in band_pass:
                 FPAM_H = 35354.3
@@ -623,7 +623,7 @@ def write_headers_FPAM(cor_type, band_pass,use_fpm,nd_filter):
     return FPAM_H, FPAM_V, FPAMNAME, FPAMSP_H, FPAMSP_V
 
 
-def write_headers_FSAM(cor_type, band_pass,slit,polaxis,use_field_stop):
+def write_headers_FSAM(cor_type, band_pass,slit,polarization_basis,use_field_stop):
     if not use_field_stop:
         FSAM_H =30677.2
         FSAM_V = 2959.5
@@ -634,11 +634,20 @@ def write_headers_FSAM(cor_type, band_pass,slit,polaxis,use_field_stop):
         ### determine the value for FSAM based on coronagraph type and bandpass
         if 'hlc' in cor_type:
             if '1' in band_pass:
-                FSAM_H = 29387
-                FSAM_V = 12238
-                FSAMNAME = 'R1C1'
-                FSAMSP_H = 29387
-                FSAMSP_V = 12238
+                if polarization_basis == 'None':
+                    #imaging mode, no polarization
+                    FSAM_H = 29387
+                    FSAM_V = 12238
+                    FSAMNAME = 'R1C1'
+                    FSAMSP_H = 29387
+                    FSAMSP_V = 12238
+                else:
+                    # polarization mode
+                    FSAM_H = 6687
+                    FSAM_V = 13738
+                    FSAMNAME = 'R1C5'
+                    FSAMSP_H = 6687
+                    FSAMSP_V = 13738
 
             if '2' in band_pass:
                 FSAM_H = 17937
@@ -662,14 +671,20 @@ def write_headers_FSAM(cor_type, band_pass,slit,polaxis,use_field_stop):
                 FSAMSP_V = 21238
 
         if 'wide' in cor_type:
-            if polaxis in ['0', '10']:
+            if polarization_basis == 'None':
+                #imaging mode, no polarization
                 FSAM_H =30677.2
                 FSAM_V = 2959.5
                 FSAMNAME = 'OPEN'
                 FSAMSP_H = 30677.2
                 FSAMSP_V = 2959.5
             else:
-                raise ValueError("Polarimetry mode has not been implemented for FSAM")
+                # polarization mode
+                FSAM_H = 6687
+                FSAM_V = 13738
+                FSAMNAME = 'R1C5'
+                FSAMSP_H = 6687
+                FSAMSP_V = 13738
 
         if ('spec' in cor_type) & ('rotated' not in cor_type):
             if '2' in band_pass:

--- a/examples/tutorial1_corgisim.ipynb
+++ b/examples/tutorial1_corgisim.ipynb
@@ -649,7 +649,11 @@
     "\n",
     "gain =100\n",
     "emccd_keywords ={'em_gain':gain}\n",
-    "detector = instrument.CorgiDetector(emccd_keywords)\n"
+    "detector = instrument.CorgiDetector(emccd_keywords)\n",
+    "\n",
+    "## the default is photon_counting = False, which will set header ISPC=0, which means the output is in analog mode. \n",
+    "# If detector = instrument.CorgiDetector(emccd_keywords, photon_counting = True), then ISPC=1, which means the output is in photon counting mode.\n",
+    "# it will not change the simulation, but only change the header keyword ISPC in the output fits file\n"
    ]
   },
   {

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -128,11 +128,11 @@ def test_L1_product_fits_format():
     assert exthdr['DPAMSP_H'] == 38917.1, f"Expected data DPAMSP_H=38917.1, but got {exthdr['DPAMSP_H']}"
     assert exthdr['DPAMSP_V'] == 26016.9, f"Expected data DPAMSP_V=26016.9, but got {exthdr['DPAMSP_V']}"
 
-    assert exthdr['FPAM_H'] ==  6757.2, f"Expected data FPAM_H= 6757.2, but got {exthdr['FPAM_H']}"
-    assert exthdr['FPAM_V'] == 22424, f"Expected data FPAM_V=22424, but got {exthdr['FPAM_V']}"
-    assert exthdr['FPAMNAME'] == 'HLC12_C2R1', f"Expected data FPAMNAME='HLC12_C2R1', but got {exthdr['FPAMNAME']}"
-    assert exthdr['FPAMSP_H'] ==  6757.2, f"Expected data FPAMSP_H= 6757.2, but got {exthdr['FPAMSP_H']}"
-    assert exthdr['FPAMSP_V'] == 22424, f"Expected data FPAMSP_V=22424, but got {exthdr['FPAMSP_V']}"
+    assert exthdr['FPAM_H'] ==  6776, f"Expected data FPAM_H= 6776, but got {exthdr['FPAM_H']}"
+    assert exthdr['FPAM_V'] == 27653.3, f"Expected data FPAM_V=27653.3, but got {exthdr['FPAM_V']}"
+    assert exthdr['FPAMNAME'] == 'HLC12_C2R5', f"Expected data FPAMNAME='HLC12_C2R5', but got {exthdr['FPAMNAME']}"
+    assert exthdr['FPAMSP_H'] ==  6776, f"Expected data FPAMSP_H= 6776, but got {exthdr['FPAMSP_H']}"
+    assert exthdr['FPAMSP_V'] == 27653.3, f"Expected data FPAMSP_V=27653.3, but got {exthdr['FPAMSP_V']}"
 
     assert exthdr['FSAM_H'] ==  29387, f"Expected data FSAM_H=29387, but got {exthdr['FSAM_H']}"
     assert exthdr['FSAM_V'] == 12238, f"Expected data FSAM_V=12238, but got {exthdr['FSAM_V']}"

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -90,7 +90,7 @@ def test_L1_product_fits_format():
     assert exthr['FSMX'] == 0.0, f"Expected data FSMX=10, but got {exthr['FSMX']}" 
     assert exthr['FSMY'] == 0.0, f"Expected data FSMY=10, but got {exthr['FSMY']}"
     assert prihr['PSFREF'] == False, f"Expected data PSFREF=False, but got {prihr['PSFREF']}"
-    assert prihr['PHTCNT'] == True, f"Expected data PSFREF=True, but got {prihr['PHTCNT']}"
+    assert prihr['PHTCNT'] == False, f"Expected data PSFREF=False, but got {prihr['PHTCNT']}"
     assert prihr['ROLL'] == 0.0, f"Expected data ROLL=0, but got {prihr['ROLL']}"
     assert prihr['PA_APER'] == 0.0, f"Expected data PA_APER=0, but got {prihr['PA_APER']}"
     assert prihr['TARGET'] == 'UNKNOWN', f"Expected header TARGET = 'UNKNOWN', but got {prihr['TARGET']}"
@@ -102,7 +102,7 @@ def test_L1_product_fits_format():
     assert exthdr['EMGAIN_A'] == 1000, f"Expected data EMGAIN_A=1000, but got {exthdr['EMGAIN_A']}"
     assert exthdr['RN'] == 165.0, f"Expected data RN=165.0, but got {exthdr['RN']}"
 
-    assert exthdr['ISPC'] == 1, f"Expected header ISPC=1, but got {exthdr['ISPC']}"
+    assert exthdr['ISPC'] == 0, f"Expected header ISPC=0, but got {exthdr['ISPC']}"
 
     assert exthdr['SPAM_H'] ==  1001.3, f"Expected data SPAM_H=1001.3, but got {exthdr['SPAM_H']}"
     assert exthdr['SPAM_V']== 16627,  f"Expected data SPAM_V = 16627, but got {exthdr['SPAM_V']}"
@@ -222,7 +222,7 @@ def test_L1_product_fits_format():
     emccd_keywords ={'em_gain':gain,'e_per_dn':e_per_dn}
     exptime = 3000
 
-    detector = instrument.CorgiDetector( emccd_keywords, photon_counting = False)
+    detector = instrument.CorgiDetector( emccd_keywords, photon_counting = True)
     sim_scene = detector.generate_detector_image(sim_scene, exptime,full_frame=True,loc_x=300, loc_y=300)
     
     ### save the L1 product fits file to test/testdata folder
@@ -252,7 +252,7 @@ def test_L1_product_fits_format():
     assert exthr['FSMX'] == 10.0, f"Expected header FSMX=10, but got {exthr['FSMX']}" 
     assert exthr['FSMY'] == 20.0, f"Expected header FSMY=10, but got {exthr['FSMY']}"
     assert prihr['PSFREF'] == True, f"Expected header PSFREF=False, but got {prihr['PSFREF']}"
-    assert prihr['PHTCNT'] == False, f"Expected header PSFREF=False, but got {prihr['PHTCNT']}"
+    assert prihr['PHTCNT'] == True, f"Expected header PSFREF=True, but got {prihr['PHTCNT']}"
     assert prihdr['FRAMET'] == exptime, f"Expected header FRAMET = {exptime}, but got {prihdr['FRAMET']}"
     assert prihr['ROLL'] == 0.0, f"Expected data ROLL=0, but got {prihr['ROLL']}"
     assert prihr['PA_APER'] == roll_angle, f"Expected data PA_APER={roll_angle}, but got {prihr['PA_APER']}"
@@ -262,7 +262,7 @@ def test_L1_product_fits_format():
     assert exthdr['KGAINPAR'] == e_per_dn, f"Expected data KGAINPAR={e_per_dn}, but got {exthdr['KGAINPAR']}"
     assert exthdr['EMGAIN_C'] == gain, f"Expected data EMGAIN_C={gain}, but got {exthdr['EMGAIN_C']}"
     assert exthdr['EMGAIN_A'] == gain, f"Expected data EMGAIN_A={gain}, but got {exthdr['EMGAIN_A']}"
-    assert exthdr['ISPC'] == 0, f"Expected header ISPC=0, but got {exthdr['ISPC']}"
+    assert exthdr['ISPC'] == 1, f"Expected header ISPC=1, but got {exthdr['ISPC']}"
     assert exthdr['EACQ_ROW'] == 300, f"Expected header EACQ_ROW=300, but got {exthdr['EACQ_ROW']}"
     assert exthdr['EACQ_COL'] == 300, f"Expected header EACQ_COL=300, but got {exthdr['EACQ_COL']}"
 

--- a/test/test_L1_product_fits_format.py
+++ b/test/test_L1_product_fits_format.py
@@ -203,8 +203,10 @@ def test_L1_product_fits_format():
     rootname = 'hlc_ni_' + cases[0]
     dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
     dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
-
-    optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':10, 'output_dim':51,\
+    
+    #define which wollaston prism to use
+    prism = 'POL0' 
+    optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':10, 'output_dim':51,'prism':prism,\
                     'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1,
                     'fsm_x_offset_mas':10.0,'fsm_y_offset_mas':20.0 }
                 ##pass fsm_x_offset_mas and fsm_y_offset_mas for no zero value as test
@@ -264,8 +266,20 @@ def test_L1_product_fits_format():
     assert exthdr['EACQ_ROW'] == 300, f"Expected header EACQ_ROW=300, but got {exthdr['EACQ_ROW']}"
     assert exthdr['EACQ_COL'] == 300, f"Expected header EACQ_COL=300, but got {exthdr['EACQ_COL']}"
 
+    assert exthdr['DPAM_H'] == 8991.3, f"Expected data DPAM_H=8991.3, but got {exthdr['DPAM_H']}"
+    assert exthdr['DPAM_V'] ==  1261.3, f"Expected data DPAM_V=1261.3, but got {exthdr['DPAM_V']}"
+    assert exthdr['DPAMNAME'] == 'POL0', f"Expected data DPAMNAME='POL0', but got {exthdr['DPAMNAME']}"
+    assert exthdr['DPAMSP_H'] == 8991.3, f"Expected data DPAMSP_H=8991.3, but got {exthdr['DPAMSP_H']}"
+    assert exthdr['DPAMSP_V'] ==  1261.3, f"Expected data DPAMSP_V=1261.3, but got {exthdr['DPAMSP_V']}"
+
+    assert exthdr['FSAM_H'] ==  6687, f"Expected data FSAM_H=6687, but got {exthdr['FSAM_H']}"
+    assert exthdr['FSAM_V'] == 13738, f"Expected data FSAM_V=13738, but got {exthdr['FSAM_V']}"
+    assert exthdr['FSAMNAME'] == 'R1C5', f"Expected data FSAMNAME='R1C5', but got {exthdr['FSAMNAME']}"
+    assert exthdr['FSAMSP_H'] ==  6687, f"Expected data FSAMSP_H=6687, but got {exthdr['FSAMSP_H']}"
+    assert exthdr['FSAMSP_V'] == 13738, f"Expected data FSAMSP_V=13738, but got {exthdr['FSAMSP_V']}"
+
     ### delete file after testing
-    print('Deleted the FITS file after testing headers populated with non-dafult values(inputs)')
+    print('Deleted the FITS file after testing headers populated with non-default values(inputs)')
     os.remove(f)
 
     ####################################################################################################

--- a/test/test_minimal.py
+++ b/test/test_minimal.py
@@ -157,11 +157,11 @@ def test_excam_mode():
     assert exthdr['DPAMSP_H'] == 38917.1, f"Expected data DPAMSP_H=38917.1, but got {exthdr['DPAMSP_H']}"
     assert exthdr['DPAMSP_V'] == 26016.9, f"Expected data DPAMSP_V=26016.9, but got {exthdr['DPAMSP_V']}"
 
-    assert exthdr['FPAM_H'] ==  6757.2, f"Expected data FPAM_H= 6757.2, but got {exthdr['FPAM_H']}"
-    assert exthdr['FPAM_V'] == 22424, f"Expected data FPAM_V=22424, but got {exthdr['FPAM_V']}"
-    assert exthdr['FPAMNAME'] == 'HLC12_C2R1', f"Expected data FPAMNAME='HLC12_C2R1', but got {exthdr['FPAMNAME']}"
-    assert exthdr['FPAMSP_H'] ==  6757.2, f"Expected data FPAMSP_H= 6757.2, but got {exthdr['FPAMSP_H']}"
-    assert exthdr['FPAMSP_V'] == 22424, f"Expected data FPAMSP_V=22424, but got {exthdr['FPAMSP_V']}"
+    assert exthdr['FPAM_H'] ==  6776, f"Expected data FPAM_H= 6776, but got {exthdr['FPAM_H']}"
+    assert exthdr['FPAM_V'] == 27653.3, f"Expected data FPAM_V=27653.3, but got {exthdr['FPAM_V']}"
+    assert exthdr['FPAMNAME'] == 'HLC12_C2R5', f"Expected data FPAMNAME='HLC12_C2R5', but got {exthdr['FPAMNAME']}"
+    assert exthdr['FPAMSP_H'] ==  6776, f"Expected data FPAMSP_H= 6776, but got {exthdr['FPAMSP_H']}"
+    assert exthdr['FPAMSP_V'] == 27653.3, f"Expected data FPAMSP_V=27653.3, but got {exthdr['FPAMSP_V']}"
 
     assert exthdr['FSAM_H'] ==  29387, f"Expected data FSAM_H=29387, but got {exthdr['FSAM_H']}"
     assert exthdr['FSAM_V'] == 12238, f"Expected data FSAM_V=12238, but got {exthdr['FSAM_V']}"

--- a/test/test_minimal.py
+++ b/test/test_minimal.py
@@ -124,14 +124,14 @@ def test_excam_mode():
     assert exthr['FSMX'] == 0.0, f"Expected data FSMX=10, but got {exthr['FSMX']}" 
     assert exthr['FSMY'] == 0.0, f"Expected data FSMY=10, but got {exthr['FSMY']}"
     assert prihr['PSFREF'] == False, f"Expected data PSFREF=False, but got {prihr['PSFREF']}"
-    assert prihr['PHTCNT'] == True, f"Expected data PSFREF=True, but got {prihr['PHTCNT']}"
+    assert prihr['PHTCNT'] == False, f"Expected data PHTCNT=False, but got {prihr['PHTCNT']}"
 
     assert exthdr['SATSPOTS'] == 0, f"Expected data SATSPOTS=0, but got {exthdr['SATSPOTS']}"
     assert exthdr['RN'] == 165.0, f"Expected data RN=165.0, but got {exthdr['RN']}"
     assert exthdr['KGAINPAR'] == 8.7, f"Expected data KGAINPAR=8.7, but got {exthdr['KGAINPAR']}"
     assert exthdr['EMGAIN_C'] == 1000, f"Expected data EMGAIN_C=1000, but got {exthdr['EMGAIN_C']}"
     assert exthdr['EMGAIN_A'] == 1000, f"Expected data EMGAIN_A=1000, but got {exthdr['EMGAIN_A']}"
-    assert exthdr['ISPC'] == 1, f"Expected header ISPC=1, but got {exthdr['ISPC']}"
+    assert exthdr['ISPC'] == 0, f"Expected header ISPC=0, but got {exthdr['ISPC']}"
 
     assert exthdr['SPAM_H'] ==  1001.3, f"Expected data SPAM_H=1001.3, but got {exthdr['SPAM_H']}"
     assert exthdr['SPAM_V']== 16627,  f"Expected data SPAM_V = 16627, but got {exthdr['SPAM_V']}"


### PR DESCRIPTION
updated the FPAM and FSAM positions used to populated in headers described in issue [#216](https://github.com/roman-corgi/corgisim/issues/216) .
The new positions are from: https://collaboration.ipac.caltech.edu/spaces/romancoronagraph/pages/254888503/CPGS+User+Guide
<img width="1258" height="291" alt="Screenshot 2026-04-29 at 4 44 20 PM" src="https://github.com/user-attachments/assets/18268944-46f0-4843-a223-a49cb2a55b0a" />

In this PR, I also change the default for photo_counting mode from true to false.
