### PR TITLE
fix roll angle convention

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1627,6 +1627,10 @@ class CorgiDetector():
 
 def skycoord_to_excamcoord(dra, ddec, roll_angle):
     """Convert sky coordinates to EXCAM coordinates. These are both relative astrometry of a companion relative to host star (or central of the frame)
+    Convention:
+    - +x = -RA
+    - +y = +Dec
+    - then rotate (x, y) counter-clockwise by roll_angle
 
     Args:
         dra (float): The right ascension offset in mas.
@@ -1639,8 +1643,13 @@ def skycoord_to_excamcoord(dra, ddec, roll_angle):
     """
     # Apply roll angle rotation
     # Because we rotate the *companion coords*, use the opposite sense: θ_comp = -roll_angle.
-    theta_comp = np.deg2rad(-1 * roll_angle)
+    theta_comp = np.deg2rad( roll_angle)
 
-    dx = dra * np.cos(theta_comp) - ddec * np.sin(theta_comp)
-    dy = dra * np.sin(theta_comp) + ddec * np.cos(theta_comp)
+    # Step 1: map sky offsets into the unrotated EXCAM frame
+    x0 = -dra
+    y0 = ddec
+
+    # Step 2: rotate the EXCAM coordinates CCW by roll_angle
+    dx = x0 * np.cos(theta_comp) - y0 * np.sin(theta_comp)
+    dy = x0 * np.sin(theta_comp) + y0 * np.cos(theta_comp)
     return dx, dy

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1643,7 +1643,7 @@ def skycoord_to_excamcoord(dra, ddec, roll_angle):
     """
     # Apply roll angle rotation
     # Because we rotate the *companion coords*, use the opposite sense: θ_comp = -roll_angle.
-    theta_comp = np.deg2rad( roll_angle)
+    theta_comp = np.deg2rad( -1*roll_angle)
 
     # Step 1: map sky offsets into the unrotated EXCAM frame
     x0 = -dra

--- a/test/test_off_axis_source.py
+++ b/test/test_off_axis_source.py
@@ -82,7 +82,7 @@ def test_off_axis_source():
     image_comp = []
     for i in range(len(mag_companion )):
 
-        params['source_x_offset_mas']=dx[i]
+        params['source_x_offset_mas']=-1*dx[i]
         params['source_y_offset_mas']=dy[i]
         comp_sim_allpol, comp_counts = cgisim.rcgisim( cgi_mode, cor_type, bandpass_cgisim,  polaxis_cgisim, params, 
         star_spectrum=sptype.lower(), star_vmag=mag_companion[i] )

--- a/test/test_roll_angle.py
+++ b/test/test_roll_angle.py
@@ -25,8 +25,8 @@ def test_roll_imaging():
     #Define companion properties
     #Add one companions, one in FOV
     mag_companion = [20]
-    companion_x_pos = [3*49.3]
-    companion_y_pos = [-3*49.3]
+    companion_x_pos = [-3*49.3]
+    companion_y_pos = [3*49.3]
     
     #### simulate using corgisim
     host_star_properties = {'Vmag': Vmag, 'spectral_type': sptype, 'magtype':'vegamag'}
@@ -81,7 +81,7 @@ def test_roll_spec():
     #Define companion properties
     #Add one companions, one in FOV
     mag_companion = [20]
-    companion_x_pos = [740]
+    companion_x_pos = [-1*740]
     companion_y_pos = [740]
     
     #### simulate using corgisim
@@ -128,11 +128,11 @@ def test_roll_spec():
     sep2_slit = np.sqrt(x2_slit**2+y2_slit**2)
     PA2_slit =  np.rad2deg(np.arctan2(y2_slit, x2_slit))
 
-    dPA = PA1-PA2
+    dPA = PA2-PA1
     assert sep1 == pytest.approx(sep2,abs=0.1), (f"Separation check failed: expected  {sep1:.3f} mas, got {sep2:.3f} mas).")
     assert dPA == pytest.approx(roll_angle,abs=0.1), (f"Roll-angle check failed: expected  {roll_angle:.3f} degree, got roll={dPA:.3f}degree).")
 
-    dPA_slit = PA1_slit-PA2_slit
+    dPA_slit = PA2_slit-PA1_slit
     assert sep1_slit == pytest.approx(sep2_slit,abs=0.1), (f"Separation for slit check failed: expected  {sep1_slit:.3f} mas, got {sep2_slit:.3f} mas).")
     assert dPA_slit == pytest.approx(roll_angle,abs=0.1), (f"Roll-angle for slit check failed: expected  {roll_angle:.3f} degree, got roll={dPA_slit:.3f}degree).")
 
@@ -152,11 +152,11 @@ def test_roll_spec():
     sep3_slit = np.sqrt(x3_slit**2+y3_slit**2)
     PA3_slit =  np.rad2deg(np.arctan2(y3_slit, x3_slit))
 
-    dPA = PA1-PA3
+    dPA = PA3-PA1
     assert sep1 == pytest.approx(sep3,abs=0.1), (f"Separation check failed: expected  {sep1:.3f} mas, got {sep3:.3f} mas).")
     assert dPA == pytest.approx(30.0,abs=0.1), (f"Roll-angle check failed: expected  {30.0:.3f} degree, got roll={dPA:.3f}degree).")
 
-    dPA_slit = PA1_slit-PA3_slit
+    dPA_slit = PA3_slit-PA1_slit
     assert sep1_slit == pytest.approx(sep3_slit,abs=0.1), (f"Separation for slit check failed: expected  {sep1_slit:.3f} mas, got {sep3_slit:.3f} mas).")
     assert dPA_slit == pytest.approx(30.0,abs=0.1), (f"Roll-angle for slit check failed: expected  {30.0:.3f} degree, got roll={dPA_slit:.3f}degree).")
 

--- a/test/test_roll_angle.py
+++ b/test/test_roll_angle.py
@@ -165,4 +165,5 @@ def test_roll_spec():
 
 if __name__ == '__main__':
     #test_roll_imaging()
+    
     test_roll_spec()

--- a/test/test_roll_angle.py
+++ b/test/test_roll_angle.py
@@ -25,7 +25,7 @@ def test_roll_imaging():
     #Define companion properties
     #Add one companions, one in FOV
     mag_companion = [20]
-    companion_x_pos = [-3*49.3]
+    companion_x_pos = [3*49.3]
     companion_y_pos = [3*49.3]
     
     #### simulate using corgisim
@@ -47,16 +47,16 @@ def test_roll_imaging():
     sim_scene_roll1 = optics_roll1.inject_point_sources(base_scene)
     x1, y1 = optics_roll1.optics_keywords_comp['source_x_offset_mas'],optics_roll1.optics_keywords_comp['source_y_offset_mas']
     sep1 = np.sqrt(x1**2+y1**2)
-    PA1 = np.rad2deg(np.arctan2(y1, x1))
+    PA1 = np.degrees(np.arctan2(x1, y1)) % 360
 
     ####second roll,roll=roll_angle
     optics_roll2 = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, roll_angle= roll_angle,if_quiet=True,oversampling_factor = 1)
     sim_scene_roll2 = optics_roll2.inject_point_sources(base_scene)
     x2, y2 = optics_roll2.optics_keywords_comp['source_x_offset_mas'],optics_roll2.optics_keywords_comp['source_y_offset_mas']
     sep2 = np.sqrt(x2**2+y2**2)
-    PA2 = np.rad2deg(np.arctan2(y2, x2))
+    PA2 = np.degrees(np.arctan2(x2, y2)) % 360
 
-    dPA = PA1-PA2
+    dPA = PA2-PA1
     assert dPA == pytest.approx(roll_angle,abs=0.1), (f"Roll-angle check failed: expected  {roll_angle:.3f} degree, got roll={dPA:.3f}degree).")
     assert sep1 == pytest.approx(sep2,abs=0.1), (f"Separation check failed: expected  {sep1:.3f} mas, got {sep2:.3f} mas).")
 
@@ -81,7 +81,7 @@ def test_roll_spec():
     #Define companion properties
     #Add one companions, one in FOV
     mag_companion = [20]
-    companion_x_pos = [-1*740]
+    companion_x_pos = [740]
     companion_y_pos = [740]
     
     #### simulate using corgisim
@@ -109,24 +109,29 @@ def test_roll_spec():
     sim_scene_roll1 = optics_roll1.inject_point_sources(base_scene)
     x1, y1 = optics_roll1.optics_keywords_comp['source_x_offset_mas'],optics_roll1.optics_keywords_comp['source_y_offset_mas']
     sep1 = np.sqrt(x1**2+y1**2)
-    PA1 = np.rad2deg(np.arctan2(y1, x1))
-  
+    ###PA here is the angle relative to the +y axis, increasing towards +x axis.
+    PA1 = np.degrees(np.arctan2(x1, y1)) % 360
+    assert x1 == pytest.approx(-1*companion_x_pos[0],abs=0.1), (f"mapping check failed: expected  {-1*companion_x_pos[0]:.3f}, got roll={x1:.3f}).")
+    assert y1 == pytest.approx(companion_y_pos[0],abs=0.1), (f"mapping check failed: expected  {companion_y_pos[0]:.3f}, got roll={y1:.3f}).")
 
     x1_slit, y1_slit =  optics_roll1.slit_x_offset_mas,optics_roll1.slit_y_offset_mas
     sep1_slit = np.sqrt(x1_slit**2+y1_slit**2)
-    PA1_slit =  np.rad2deg(np.arctan2(y1_slit, x1_slit))
+    PA1_slit =  np.degrees(np.arctan2(x1_slit, y1_slit)) % 360
+    assert x1_slit == pytest.approx(-1*source_x_offset_mas,abs=0.1), (f"mapping check failed: expected  {-1*source_x_offset_mas:.3f}, got roll={x1_slit:.3f}).")
+    assert y1_slit == pytest.approx(source_y_offset_mas,abs=0.1), (f"mapping check failed: expected  {source_y_offset_mas:.3f}, got roll={y1_slit:.3f}).")
+
 
     ####second roll,roll=roll_angle
     optics_roll2 = instrument.CorgiOptics(cgi_mode, bandpass_corgisim, optics_keywords=optics_keywords, roll_angle= roll_angle,if_quiet=True,oversampling_factor = 1)
     sim_scene_roll2 = optics_roll2.inject_point_sources(base_scene)
     x2, y2 = optics_roll2.optics_keywords_comp['source_x_offset_mas'],optics_roll2.optics_keywords_comp['source_y_offset_mas']
     sep2 = np.sqrt(x2**2+y2**2)
-    PA2 = np.rad2deg(np.arctan2(y2, x2))
+    PA2 = np.degrees(np.arctan2(x2, y2)) % 360
 
 
     x2_slit, y2_slit =  optics_roll2.slit_x_offset_mas,optics_roll2.slit_y_offset_mas
     sep2_slit = np.sqrt(x2_slit**2+y2_slit**2)
-    PA2_slit =  np.rad2deg(np.arctan2(y2_slit, x2_slit))
+    PA2_slit =  np.degrees(np.arctan2(x2_slit, y2_slit)) % 360
 
     dPA = PA2-PA1
     assert sep1 == pytest.approx(sep2,abs=0.1), (f"Separation check failed: expected  {sep1:.3f} mas, got {sep2:.3f} mas).")
@@ -146,11 +151,11 @@ def test_roll_spec():
     assert y3_slit != y2_slit
     
     sep3 = np.sqrt(x3**2+y3**2)
-    PA3 = np.rad2deg(np.arctan2(y3, x3))
+    PA3 = np.degrees(np.arctan2(x3, y3)) % 360
 
 
     sep3_slit = np.sqrt(x3_slit**2+y3_slit**2)
-    PA3_slit =  np.rad2deg(np.arctan2(y3_slit, x3_slit))
+    PA3_slit =  np.degrees(np.arctan2(x3_slit, y3_slit)) % 360
 
     dPA = PA3-PA1
     assert sep1 == pytest.approx(sep3,abs=0.1), (f"Separation check failed: expected  {sep1:.3f} mas, got {sep3:.3f} mas).")
@@ -165,5 +170,4 @@ def test_roll_spec():
 
 if __name__ == '__main__':
     #test_roll_imaging()
-    
     test_roll_spec()

--- a/test/test_roll_angle.py
+++ b/test/test_roll_angle.py
@@ -111,14 +111,14 @@ def test_roll_spec():
     sep1 = np.sqrt(x1**2+y1**2)
     ###PA here is the angle relative to the +y axis, increasing towards +x axis.
     PA1 = np.degrees(np.arctan2(x1, y1)) % 360
-    assert x1 == pytest.approx(-1*companion_x_pos[0],abs=0.1), (f"mapping check failed: expected  {-1*companion_x_pos[0]:.3f}, got roll={x1:.3f}).")
-    assert y1 == pytest.approx(companion_y_pos[0],abs=0.1), (f"mapping check failed: expected  {companion_y_pos[0]:.3f}, got roll={y1:.3f}).")
+    assert x1 == pytest.approx(-1*companion_x_pos[0],abs=0.1), (f"mapping check failed: expected  {-1*companion_x_pos[0]:.3f}, got x position={x1:.3f}).")
+    assert y1 == pytest.approx(companion_y_pos[0],abs=0.1), (f"mapping check failed: expected  {companion_y_pos[0]:.3f}, got y position={y1:.3f}).")
 
     x1_slit, y1_slit =  optics_roll1.slit_x_offset_mas,optics_roll1.slit_y_offset_mas
     sep1_slit = np.sqrt(x1_slit**2+y1_slit**2)
     PA1_slit =  np.degrees(np.arctan2(x1_slit, y1_slit)) % 360
-    assert x1_slit == pytest.approx(-1*source_x_offset_mas,abs=0.1), (f"mapping check failed: expected  {-1*source_x_offset_mas:.3f}, got roll={x1_slit:.3f}).")
-    assert y1_slit == pytest.approx(source_y_offset_mas,abs=0.1), (f"mapping check failed: expected  {source_y_offset_mas:.3f}, got roll={y1_slit:.3f}).")
+    assert x1_slit == pytest.approx(-1*source_x_offset_mas,abs=0.1), (f"mapping check failed: expected  {-1*source_x_offset_mas:.3f}, got slit x position={x1_slit:.3f}).")
+    assert y1_slit == pytest.approx(source_y_offset_mas,abs=0.1), (f"mapping check failed: expected  {source_y_offset_mas:.3f}, got slit y position={y1_slit:.3f}).")
 
 
     ####second roll,roll=roll_angle

--- a/test/test_spc_mode.py
+++ b/test/test_spc_mode.py
@@ -61,7 +61,7 @@ def test_spc_mode():
     
     image_comp = []
     for i in range(len(mag_companion)):
-        params['source_x_offset_mas'] = companion_x_pos[i]
+        params['source_x_offset_mas'] = -1*companion_x_pos[i]
         params['source_y_offset_mas'] = companion_y_pos[i]
         comp_sim_allpol, comp_counts = cgisim.rcgisim(cgi_mode, cor_type, bandpass_cgisim,  polaxis_cgisim, params, 
         star_spectrum = sptype.lower(), star_vmag = mag_companion[i])


### PR DESCRIPTION
## Purpose

The convention used by `corgisim` to map sky-plane coordinates to EXCAM coordinates and apply the roll angle was incorrect. This PR fixes that convention.

The correct convention is:

- In the sky plane, east is 90 degrees counterclockwise from north.
- In the EXCAM plane, the positive x-axis is 90 degrees clockwise from the positive y-axis.
- When `roll = 0`, north is aligned with positive y, and east is aligned with negative x.
- A positive roll angle means the EXCAM x-y frame rotates counterclockwise relative to the sky-plane coordinates.

The definition is described here: [add https://collaboration.ipac.caltech.edu/pages/viewpage.action?pageId=223743972&spaceKey=romancoronagraph&title=PA_APER%2Band%2BROLL%2Bangle%2Bconventions]
<img width="436" height="460" alt="Screenshot 2026-04-30 at 5 02 40 PM" src="https://github.com/user-attachments/assets/1b0883fb-1f2f-4638-99bf-389d18f8ea74" />



## Summary of Changes

**Major updates** to `instrument.py` and `test_roll_angle.py`.