### PR TITLE
split complete test into two jobs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,8 +15,27 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-24.04
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: heavy
+            pytest_args: >-
+              ./test/test_jitter.py
+              ./test/test_minimal.py
+              ./test/test_L1_product_fits_format.py
+              ./test/test_L1_product_fits_format_specmode.py
+              ./test/test_observation_sequence.py
+          - shard: rest
+            pytest_args: >-
+              ./test
+              --ignore=./test/test_jitter.py
+              --ignore=./test/test_minimal.py
+              --ignore=./test/test_L1_product_fits_format.py
+              --ignore=./test/test_L1_product_fits_format_specmode.py
+              --ignore=./test/test_observation_sequence.py
 
     steps:
     - uses: actions/checkout@v4
@@ -35,31 +54,31 @@ jobs:
         wget https://sourceforge.net/projects/proper-library/files/proper_v3.3.4_python.zip && unzip proper_v3.3.4_python.zip
         cd proper_v3.3.4_python/
         python -m pip install .
-        cd ..        
+        cd ..
     - name: Download and install Roman preflight
       run: |
         git clone https://github.com/roman-corgi/cgisim_cpp
         cd cgisim_cpp/
         python -m pip install .
-        cd ..   
+        cd ..
     - name: Download and install eetc
       run: |
-        git clone https://github.com/nasa-jpl/cgi-eetc.git  
+        git clone https://github.com/nasa-jpl/cgi-eetc.git
         cd cgi-eetc/
         python -m pip install .
-        cd ..        
+        cd ..
     - name: Download and install CGISim
       run: |
-        wget https://sourceforge.net/projects/cgisim/files/cgisim_v4.1.zip  && unzip  cgisim_v4.1.zip
-        cd  cgisim_v4.1/
+        wget https://sourceforge.net/projects/cgisim/files/cgisim_v4.1.zip && unzip cgisim_v4.1.zip
+        cd cgisim_v4.1/
         python -m pip install .
-        cd ..   
-        
+        cd ..
+
     - name: Set Swap Space
       uses: pierotofy/set-swap-space@master
       with:
         swap-size-gb: 10
 
-    - name: Test with pytest
+    - name: Test with pytest (${{ matrix.shard }})
       run: |
-        pytest ./test
+        pytest ${{ matrix.pytest_args }}


### PR DESCRIPTION
The complete test hit the max running time of 6 hr. In this PR, I change the python-app.yml to spilt the complete test into two separte jobs. 

--heavy job: including below

./test/test_jitter.py
./test/test_minimal.py
./test/test_L1_product_fits_format.py
 ./test/test_L1_product_fits_format_specmode.py
./test/test_observation_sequence.py


--rest job: all other test files except for the 5 tests in heavy jobs