### PR TITLE
make wavelength the same for satspot and instrument

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -331,7 +331,6 @@ class CorgiOptics():
                 satspot_keywords['wavelength_m'] =  optics_keywords_internal['lam0']*1e-6
             elif  satspot_keywords['wavelength_m'] !=  optics_keywords_internal['lam0']*1e-6:
                 warnings.warn('The satellite spot wavelength is different from the optics wavelength ', UserWarning)
-git 
             required_keys_satspot = {'num_pairs','sep_lamD', 'angle_deg', 'contrast', 'wavelength_m'}
             missing_keys = required_keys_satspot - satspot_keywords.keys()
             if missing_keys:

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -329,7 +329,7 @@ class CorgiOptics():
             if optics_keywords['use_dm1'] != 1:
                 raise KeyError('ERROR: use_dm1 in optics_keywords is not set 1')
             if 'wavelength_m' not in satspot_keywords.keys():
-                satspot_keywords['wavelength_m'] =  optics_keywords_internal['lam0']*1e-6
+                satspot_keywords['wavelength_m'] =  self.lam0_um*1e-6
             elif not math.isclose(self.lam0_um * 1e-6, satspot_keywords['wavelength_m'] , rel_tol=1e-7):
                 warnings.warn('The satellite spot wavelength is different from the optics wavelength ', UserWarning)
             required_keys_satspot = {'num_pairs','sep_lamD', 'angle_deg', 'contrast', 'wavelength_m'}

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1347,10 +1347,9 @@ class CorgiOptics():
         inverse_satspot = satspot_keywords.copy()
         inverse_satspot["sign"] = sign
 
-        # Remove satspots
-        self.add_satspot(inverse_satspots)
+        self.add_satspot(inverse_satspot)
 
-        # Update keywords
+        # Update header
         self.SATSPOTS = int(0)
 
 

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -322,26 +322,12 @@ class CorgiOptics():
         ##self.SATSPOTS is the value to be populated to L1 header prihdr[SATSPOTS]
         # prihdr[SATSPOTS]= 0: No satellite spots present 
         # prihdr[SATSPOTS]= 1: Satellite spots present
-        if satspot_keywords == None:
-            self.SATSPOTS = int(0)
-        else:
-            # check keywords
-            if optics_keywords['use_dm1'] != 1:
-                raise KeyError('ERROR: use_dm1 in optics_keywords is not set 1')
-            if 'wavelength_m' not in satspot_keywords.keys():
-                satspot_keywords['wavelength_m'] =  self.lam0_um*1e-6
-            elif not math.isclose(self.lam0_um * 1e-6, satspot_keywords['wavelength_m'] , rel_tol=1e-7):
-                warnings.warn('The satellite spot wavelength is different from the optics wavelength ', UserWarning)
-            required_keys_satspot = {'num_pairs','sep_lamD', 'angle_deg', 'contrast', 'wavelength_m'}
-            missing_keys = required_keys_satspot - satspot_keywords.keys()
-            if missing_keys:
-                raise KeyError(f"ERROR: Missing required satspot_keywords: {missing_keys}")
 
-            #### call self.add_satspot() to satellite spots in DM files, update the dm1 info in self.optics_keywords
-            self.optics_keywords['dm1_v'] = self.add_satspot(satspot_keywords=satspot_keywords)
 
-            self.SATSPOTS = int(1)
-            print("satellite spots are added to DM1.")
+        # call self.add_satspot() to satellite spots in DM files, update the dm1 info in self.optics_keywords
+        self.add_satspot(satspot_keywords=satspot_keywords)
+
+
 
         # Finite stellar diameter and jitter
         # Ignore this section if stellar_diam_and_jitter_keywords == None
@@ -1304,31 +1290,55 @@ class CorgiOptics():
 
         Returns:
         -------
-        dm1_cos_added : 2D ndarray
-            Updated DM1 voltage map with satellite spots added.
-       
+
         """
+        if satspot_keywords == None:
+            self.SATSPOTS = int(0)
+        else:
+            # check keywords
+            if self.optics_keywords['use_dm1'] != 1:
+                raise KeyError('ERROR: use_dm1 in optics_keywords is not set 1')
+            if 'wavelength_m' not in satspot_keywords.keys():
+                satspot_keywords['wavelength_m'] =  self.lam0_um*1e-6
+            elif not math.isclose(self.lam0_um * 1e-6, satspot_keywords['wavelength_m'] , rel_tol=1e-7):
+                warnings.warn('The satellite spot wavelength is different from the optics wavelength ', UserWarning)
+            required_keys_satspot = {'num_pairs','sep_lamD', 'angle_deg', 'contrast', 'wavelength_m'}
+            missing_keys = required_keys_satspot - satspot_keywords.keys()
+            if missing_keys:
+                raise KeyError(f"ERROR: Missing required satspot_keywords: {missing_keys}")
 
-        # extract DM1
-        proper_keywords = self.optics_keywords.copy()
-        dm1_input = proper_keywords['dm1_v']
+            # extract DM1
+            proper_keywords = self.optics_keywords.copy()
+            dm1_input = proper_keywords['dm1_v']
 
-        # extract satspot_keywords
-        num_pairs = satspot_keywords['num_pairs']
-        sep_lamD = satspot_keywords['sep_lamD']
-        angle_deg = satspot_keywords['angle_deg']
-        contrast = satspot_keywords['contrast']
-        wavelength_m = satspot_keywords['wavelength_m']
+            # extract satspot_keywords
+            num_pairs = satspot_keywords['num_pairs']
+            sep_lamD = satspot_keywords['sep_lamD']
+            angle_deg = satspot_keywords['angle_deg']
+            contrast = satspot_keywords['contrast']
+            wavelength_m = satspot_keywords['wavelength_m']
 
-                    #If the user doesn't pass in the 
-        if "sign" not in satspot_keywords.keys():
-                sign = "positive"
-        else: 
-                sign = satspot_keywords["sign"]
+                        #If the user doesn't pass in the 
+            if "sign" not in satspot_keywords.keys():
+                    sign = "positive"
+            else: 
+                    sign = satspot_keywords["sign"]
 
-        dm1_cos_added = add_cos_pattern_dm(dm1_input,num_pairs,sep_lamD,angle_deg,contrast,wavelength_m, sign = sign)
+            self.optics_keywords['dm1_v'] = add_cos_pattern_dm(dm1_input,num_pairs,sep_lamD,angle_deg,contrast,wavelength_m, sign = sign)
+            
+            self.SATSPOTS = int(1)
 
-        return dm1_cos_added
+    def add_satspot(self,satspot_keywords):
+        """
+        Remove satellite spots from deformable mirror (DM) settings.
+
+        Parameters:
+        ----------
+        satspot_keywords : dict
+            Dictionary specifying the parameters needed to define and inject 
+            satellite spots (sep_lamD, angle_deg, contrast, wavelength_m, sign(options)).
+        """
+        
 
     def generate_full_aberration_psf(self, optics_keywords,is_offaxis_source=False):
         '''
@@ -1367,6 +1377,7 @@ class CorgiOptics():
                 # also, the jitter model isn't currently set up for offaxis sources
                 images_tem = np.array(sum(images_pol)) / 4
         return images_tem
+        
     @property
     def roll_angle(self):
         '''

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -327,6 +327,11 @@ class CorgiOptics():
             # check keywords
             if optics_keywords['use_dm1'] != 1:
                 raise KeyError('ERROR: use_dm1 in optics_keywords is not set 1')
+            if 'wavelength_m' not in satspot_keywords.keys():
+                satspot_keywords['wavelength_m'] =  optics_keywords_internal['lam0']*1e-6
+            elif  satspot_keywords['wavelength_m'] !=  optics_keywords_internal['lam0']*1e-6:
+                warnings.warn('The satellite spot wavelength is different from the optics wavelength ', UserWarning)
+git 
             required_keys_satspot = {'num_pairs','sep_lamD', 'angle_deg', 'contrast', 'wavelength_m'}
             missing_keys = required_keys_satspot - satspot_keywords.keys()
             if missing_keys:

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -325,6 +325,7 @@ class CorgiOptics():
 
 
         # call self.add_satspot() to satellite spots in DM files, update the dm1 info in self.optics_keywords
+        self.SATSPOTS = 0
         self.add_satspot(satspot_keywords=satspot_keywords)
 
 
@@ -1308,8 +1309,7 @@ class CorgiOptics():
                 raise KeyError(f"ERROR: Missing required satspot_keywords: {missing_keys}")
 
             # extract DM1
-            proper_keywords = self.optics_keywords.copy()
-            dm1_input = proper_keywords['dm1_v']
+            dm1_input = self.optics_keywords['dm1_v']
 
             # extract satspot_keywords
             num_pairs = satspot_keywords['num_pairs']
@@ -1318,7 +1318,7 @@ class CorgiOptics():
             contrast = satspot_keywords['contrast']
             wavelength_m = satspot_keywords['wavelength_m']
 
-                        #If the user doesn't pass in the 
+            #If the user doesn't pass in the sign
             if "sign" not in satspot_keywords.keys():
                     sign = "positive"
             else: 
@@ -1328,17 +1328,31 @@ class CorgiOptics():
             
             self.SATSPOTS = int(1)
 
-    def add_satspot(self,satspot_keywords):
+    def remove_satspot(self, satspot_keywords):
         """
         Remove satellite spots from deformable mirror (DM) settings.
 
         Parameters:
         ----------
         satspot_keywords : dict
-            Dictionary specifying the parameters needed to define and inject 
+            Dictionary specifying the parameters needed to define and REMOVE 
             satellite spots (sep_lamD, angle_deg, contrast, wavelength_m, sign(options)).
         """
-        
+        # Inverse the sign
+        if "sign" not in satspot_keywords.keys() or satspot_keywords["sign"] == "positive":
+            sign = "negative"
+        else :
+            sign = "positive"
+
+        inverse_satspot = satspot_keywords.copy()
+        inverse_satspot["sign"] = sign
+
+        # Remove satspots
+        self.add_satspot(inverse_satspots)
+
+        # Update keywords
+        self.SATSPOTS = int(0)
+
 
     def generate_full_aberration_psf(self, optics_keywords,is_offaxis_source=False):
         '''

--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -18,6 +18,7 @@ import copy
 import os
 from scipy import interpolate
 from packaging.version import Version
+import math
 
 warnings.simplefilter('always', UserWarning)
 class CorgiOptics():
@@ -329,7 +330,7 @@ class CorgiOptics():
                 raise KeyError('ERROR: use_dm1 in optics_keywords is not set 1')
             if 'wavelength_m' not in satspot_keywords.keys():
                 satspot_keywords['wavelength_m'] =  optics_keywords_internal['lam0']*1e-6
-            elif  satspot_keywords['wavelength_m'] !=  optics_keywords_internal['lam0']*1e-6:
+            elif not math.isclose(self.lam0_um * 1e-6, satspot_keywords['wavelength_m'] , rel_tol=1e-7):
                 warnings.warn('The satellite spot wavelength is different from the optics wavelength ', UserWarning)
             required_keys_satspot = {'num_pairs','sep_lamD', 'angle_deg', 'contrast', 'wavelength_m'}
             missing_keys = required_keys_satspot - satspot_keywords.keys()

--- a/test/test_add_satellite_spots.py
+++ b/test/test_add_satellite_spots.py
@@ -33,7 +33,7 @@ def test_add_satellite_spots():
     ##  Define the polaxis parameter. Use 10 for non-polaxis cases only, as other options are not yet implemented.
     polaxis = 10
     # output_dim define the size of the output image
-    output_dim = 51
+    output_dim = 201
 
 
     ## 1) simulate an offset stellar PSF, as a reference ##
@@ -42,7 +42,7 @@ def test_add_satellite_spots():
     lam_D = np.degrees(wavelength/2.3)*3600*1000 # in mas
     shift = [0, 6*lam_D] # shift in [x,y]
 
-    optics_keywords ={'cor_type':cor_type, 'use_errors':2, 'polaxis':polaxis, 'output_dim':output_dim,\
+    optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':polaxis, 'output_dim':output_dim,\
                     'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1,\
                  'source_x_offset_mas': shift[0], 'source_y_offset_mas': shift[1]}
 
@@ -54,7 +54,7 @@ def test_add_satellite_spots():
     image_star = sim_scene.host_star_image.data
 
     ## 2) simulate satellite spots by modifying the DM1 solutions ##
-    optics_keywords_ss ={'cor_type':cor_type, 'use_errors':2, 'polaxis':polaxis, 'output_dim':output_dim,\
+    optics_keywords_ss ={'cor_type':cor_type, 'use_errors':1, 'polaxis':polaxis, 'output_dim':output_dim,\
                         'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
     
     for sign in [None,"positive", "negative"]:
@@ -65,8 +65,7 @@ def test_add_satellite_spots():
             satspot_keywords = {'num_pairs':2, 'sep_lamD': 7, 'angle_deg': [0,90], 'contrast': contrast, 'wavelength_m': wavelength, 'sign': sign}
 
         ##define the corgi.optics class that hold all information about the instrument paramters                    
-        optics_with_spots = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords_ss, satspot_keywords=satspot_keywords, if_quiet=True)
-        
+        optics_with_spots = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords_ss,satspot_keywords=satspot_keywords, if_quiet=True)
         #Check that the wavelength is the one commanded by optics
         assert math.isclose(optics.lam0_um*1e-6, satspot_keywords['wavelength_m'] , rel_tol=1e-7)
 
@@ -110,5 +109,76 @@ def test_add_satellite_spots():
         assert peak_satspots_ave/(peak_ref*contrast) < 1.5, peak_satspots_ave/(peak_ref*contrast) > 0.5 
         #threshold is set to 50%
 
+        # Remove satellite spots
+        optics.remove_satspot(satspot_keywords)
+        assert optics.SATSPOTS == 0
+
+        sim_scene_without_spots = optics.get_host_star_psf(base_scene)
+        image_star_without_spots = sim_scene_without_spots.host_star_image.data
+
+        #res = np.allclose(image_star_without_spots, image_star, rtol=1e-05, atol=1e-08)
+        #assert res
+
+def test_add_remove_satellite_spots():
+    Vmag = 5                            # V-band magnitude of the host star
+    sptype = 'G0V'                      # Spectral type of the host star
+    host_star_properties = {'Vmag': Vmag,
+                        'spectral_type': sptype,
+                        'magtype': 'vegamag'}
+    # contrast of satellite spots
+    contrast = 1e-5
+    ####
+
+    # --- Create the Astrophysical Scene ---
+    base_scene = scene.Scene(host_star_properties)
+
+    # Simulation mode (currently only 'excam' is implemented)
+    cgi_mode = 'excam'
+    cor_type = 'hlc'
+    bandpass = '1'
+    cases = ['3e-8']       
+    rootname = 'hlc_ni_' + cases[0]
+    dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
+    dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
+
+    ##  Define the polaxis parameter. Use 10 for non-polaxis cases only, as other options are not yet implemented.
+    polaxis = 10
+    # output_dim define the size of the output image
+    output_dim = 201
+    wavelength = 0.575e-6 # meter, assuming band 1
+    
+    optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':polaxis, 'output_dim':output_dim,\
+                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
+    
+    satspot_keywords = {'num_pairs':2, 'sep_lamD': 7, 'angle_deg': [0,90], 'contrast': contrast}
+
+    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)
+
+    sim_scene = optics.get_host_star_psf(base_scene)
+    image_star = sim_scene.host_star_image.data
+
+
+    optics_with_spots =  instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, satspot_keywords=satspot_keywords, if_quiet=True)                  
+    optics.add_satspot(satspot_keywords)
+
+    sim_scene_with_spots = optics_with_spots.get_host_star_psf(base_scene)
+    image_star_with_spots = sim_scene_with_spots.host_star_image.data
+
+    sim_scene_with_spots_added = optics.get_host_star_psf(base_scene)
+    image_star_with_spots_added = sim_scene_with_spots_added.host_star_image.data
+    
+    assert np.all(optics.optics_keywords["dm1_v"] == optics_with_spots.optics_keywords["dm1_v"])
+    assert np.all(image_star_with_spots_added == image_star_with_spots)
+
+    optics.remove_satspot(satspot_keywords)
+    sim_scene_with_spots_removed = optics.get_host_star_psf(base_scene)
+    image_star_with_spots_removed = sim_scene_with_spots_removed.host_star_image.data
+
+    assert np.all(image_star_with_spots_removed == image_star)
+    assert np.allclose(optics.optics_keywords["dm1_v"], dm1,rtol=1e-15, atol=1e-15)
+
+
+
 if __name__ == '__main__':
     test_add_satellite_spots()
+    

--- a/test/test_add_satellite_spots.py
+++ b/test/test_add_satellite_spots.py
@@ -207,7 +207,7 @@ def test_measure_offset(coro_type, sep_lamD, angle_deg, band,wavelength):
     optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':polaxis, 'output_dim':output_dim,\
                     'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1,\
                  'source_x_offset_mas': shift[0], 'source_y_offset_mas': shift[1]}
-    satspot_keywords = {'num_pairs':2, 'sep_lamD': 6.5, 'angle_deg': [0,90], 'contrast': contrast}
+    satspot_keywords = {'num_pairs':2, 'sep_lamD':sep_lamD, 'angle_deg': angle_deg, 'contrast': contrast}
 
     ##define the corgi.optics class that hold all information about the instrument paramters
     optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)

--- a/test/test_add_satellite_spots.py
+++ b/test/test_add_satellite_spots.py
@@ -3,6 +3,7 @@ import numpy as np
 import proper
 import roman_preflight_proper
 from pyklip.fakes import gaussfit2d
+import math
 
 def test_add_satellite_spots():
     
@@ -59,12 +60,15 @@ def test_add_satellite_spots():
     for sign in [None,"positive", "negative"]:
 
         if sign is None:
-            satspot_keywords = {'num_pairs':2, 'sep_lamD': 7, 'angle_deg': [0,90], 'contrast': contrast, 'wavelength_m': wavelength}
+            satspot_keywords = {'num_pairs':2, 'sep_lamD': 7, 'angle_deg': [0,90], 'contrast': contrast}
         else: 
             satspot_keywords = {'num_pairs':2, 'sep_lamD': 7, 'angle_deg': [0,90], 'contrast': contrast, 'wavelength_m': wavelength, 'sign': sign}
 
         ##define the corgi.optics class that hold all information about the instrument paramters                    
         optics_with_spots = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords_ss, satspot_keywords=satspot_keywords, if_quiet=True)
+        
+        #Check that the wavelength is the one commanded by optics
+        assert math.isclose(optics.lam0_um*1e-6, satspot_keywords['wavelength_m'] , rel_tol=1e-7)
 
         sim_scene_with_spots = optics_with_spots.get_host_star_psf(base_scene)
         image_star_with_spots = sim_scene_with_spots.host_star_image.data

--- a/test/test_add_satellite_spots.py
+++ b/test/test_add_satellite_spots.py
@@ -113,6 +113,9 @@ def test_add_satellite_spots():
 
 @pytest.mark.parametrize("coro_type, sep_lamD, angle_deg, band", [("hlc", 6.5, [0,90], "1"), ("spc-wide", 13, [0,90],"4"), ("hlc", 6.5, [45,135], "1"),("spc-wide", 13, [45,135],"4"),])
 def test_add_remove_satellite_spots(coro_type, sep_lamD, angle_deg, band):
+    """
+    Verifies that the satellite spots can be added and removed from an optics object
+    """
     Vmag = 5                            # V-band magnitude of the host star
     sptype = 'G0V'                      # Spectral type of the host star
     host_star_properties = {'Vmag': Vmag,
@@ -136,8 +139,7 @@ def test_add_remove_satellite_spots(coro_type, sep_lamD, angle_deg, band):
     ##  Define the polaxis parameter. Use 10 for non-polaxis cases only, as other options are not yet implemented.
     polaxis = 10
     # output_dim define the size of the output image
-    output_dim = 201
-    #wavelength = 0.575e-6 # meter, assuming band 1
+    output_dim = 101
     
     optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':polaxis, 'output_dim':output_dim,\
                         'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
@@ -152,6 +154,7 @@ def test_add_remove_satellite_spots(coro_type, sep_lamD, angle_deg, band):
 
     optics_with_spots =  instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, satspot_keywords=satspot_keywords, if_quiet=True)                  
     optics.add_satspot(satspot_keywords)
+    #Check that the keywords used in the headers have been modified 
     assert optics.SATSPOTS == 1
 
     sim_scene_with_spots = optics_with_spots.get_host_star_psf(base_scene)
@@ -160,7 +163,9 @@ def test_add_remove_satellite_spots(coro_type, sep_lamD, angle_deg, band):
     sim_scene_with_spots_added = optics.get_host_star_psf(base_scene)
     image_star_with_spots_added = sim_scene_with_spots_added.host_star_image.data
     
+    #Check that the deformable mirrors are identical
     assert np.all(optics.optics_keywords["dm1_v"] == optics_with_spots.optics_keywords["dm1_v"])
+    #Check that the generated images are identical
     assert np.all(image_star_with_spots_added == image_star_with_spots)
 
     optics.remove_satspot(satspot_keywords)
@@ -173,6 +178,9 @@ def test_add_remove_satellite_spots(coro_type, sep_lamD, angle_deg, band):
 
 @pytest.mark.parametrize("coro_type, sep_lamD, angle_deg, band, wavelength", [("hlc", 6.5, [0,90], "1", 0.575e-6), ("spc-wide", 13, [0,90],"4",0.825e-6), ("hlc", 6.5, [45,135], "1",0.575e-6),("spc-wide", 13, [45,135],"4",0.825e-6),])
 def test_measure_offset(coro_type, sep_lamD, angle_deg, band,wavelength):
+    """
+    Verifies that the satellite spots are centered around the star even if the star is not in the middle of the image
+    """
     Vmag = 5                            # V-band magnitude of the host star
     sptype = 'G0V'                      # Spectral type of the host star
     host_star_properties = {'Vmag': Vmag,

--- a/test/test_add_satellite_spots.py
+++ b/test/test_add_satellite_spots.py
@@ -1,4 +1,5 @@
 from corgisim import scene,instrument
+import pytest
 import numpy as np
 import proper
 import roman_preflight_proper
@@ -33,7 +34,7 @@ def test_add_satellite_spots():
     ##  Define the polaxis parameter. Use 10 for non-polaxis cases only, as other options are not yet implemented.
     polaxis = 10
     # output_dim define the size of the output image
-    output_dim = 201
+    output_dim = 101
 
 
     ## 1) simulate an offset stellar PSF, as a reference ##
@@ -109,17 +110,69 @@ def test_add_satellite_spots():
         assert peak_satspots_ave/(peak_ref*contrast) < 1.5, peak_satspots_ave/(peak_ref*contrast) > 0.5 
         #threshold is set to 50%
 
-        # Remove satellite spots
-        optics.remove_satspot(satspot_keywords)
-        assert optics.SATSPOTS == 0
 
-        sim_scene_without_spots = optics.get_host_star_psf(base_scene)
-        image_star_without_spots = sim_scene_without_spots.host_star_image.data
+@pytest.mark.parametrize("coro_type, sep_lamD, angle_deg, band", [("hlc", 6.5, [0,90], "1"), ("spc-wide", 13, [0,90],"4"), ("hlc", 6.5, [45,135], "1"),("spc-wide", 13, [45,135],"4"),])
+def test_add_remove_satellite_spots(coro_type, sep_lamD, angle_deg, band):
+    Vmag = 5                            # V-band magnitude of the host star
+    sptype = 'G0V'                      # Spectral type of the host star
+    host_star_properties = {'Vmag': Vmag,
+                            'spectral_type': sptype,
+                            'magtype': 'vegamag'}
+    # contrast of satellite spots
+    contrast = 1e-5
+    ####
 
-        #res = np.allclose(image_star_without_spots, image_star, rtol=1e-05, atol=1e-08)
-        #assert res
+    # --- Create the Astrophysical Scene ---
+    base_scene = scene.Scene(host_star_properties)
 
-def test_add_remove_satellite_spots():
+    # Simulation mode (currently only 'excam' is implemented)
+    cgi_mode = 'excam'
+    cor_type = coro_type
+    bandpass = band
+    rootname = cor_type+'_ni_5e-9'
+    dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
+    dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
+
+    ##  Define the polaxis parameter. Use 10 for non-polaxis cases only, as other options are not yet implemented.
+    polaxis = 10
+    # output_dim define the size of the output image
+    output_dim = 201
+    #wavelength = 0.575e-6 # meter, assuming band 1
+    
+    optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':polaxis, 'output_dim':output_dim,\
+                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
+    
+    satspot_keywords = {'num_pairs':2, 'sep_lamD': sep_lamD, 'angle_deg': angle_deg, 'contrast': contrast}
+
+    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)
+
+    sim_scene = optics.get_host_star_psf(base_scene)
+    image_star = sim_scene.host_star_image.data
+
+
+    optics_with_spots =  instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, satspot_keywords=satspot_keywords, if_quiet=True)                  
+    optics.add_satspot(satspot_keywords)
+    assert optics.SATSPOTS == 1
+
+    sim_scene_with_spots = optics_with_spots.get_host_star_psf(base_scene)
+    image_star_with_spots = sim_scene_with_spots.host_star_image.data
+
+    sim_scene_with_spots_added = optics.get_host_star_psf(base_scene)
+    image_star_with_spots_added = sim_scene_with_spots_added.host_star_image.data
+    
+    assert np.all(optics.optics_keywords["dm1_v"] == optics_with_spots.optics_keywords["dm1_v"])
+    assert np.all(image_star_with_spots_added == image_star_with_spots)
+
+    optics.remove_satspot(satspot_keywords)
+    sim_scene_with_spots_removed = optics.get_host_star_psf(base_scene)
+    image_star_with_spots_removed = sim_scene_with_spots_removed.host_star_image.data
+    
+    assert optics.SATSPOTS == 0
+    assert np.all(image_star_with_spots_removed == image_star)
+    assert np.allclose(optics.optics_keywords["dm1_v"], dm1,rtol=1e-15, atol=1e-15)
+
+@pytest.mark.parametrize("coro_type, sep_lamD, angle_deg, band, wavelength", [("hlc", 6.5, [0,90], "1", 0.575e-6), ("spc-wide", 13, [0,90],"4",0.825e-6), ("hlc", 6.5, [45,135], "1",0.575e-6),("spc-wide", 13, [45,135],"4",0.825e-6),])
+def test_measure_offset(coro_type, sep_lamD, angle_deg, band,wavelength):
     Vmag = 5                            # V-band magnitude of the host star
     sptype = 'G0V'                      # Spectral type of the host star
     host_star_properties = {'Vmag': Vmag,
@@ -134,51 +187,81 @@ def test_add_remove_satellite_spots():
 
     # Simulation mode (currently only 'excam' is implemented)
     cgi_mode = 'excam'
-    cor_type = 'hlc'
-    bandpass = '1'
-    cases = ['3e-8']       
-    rootname = 'hlc_ni_' + cases[0]
+    cor_type = coro_type
+    bandpass = band
+    rootname = cor_type+'_ni_5e-9'
     dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
     dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
 
     ##  Define the polaxis parameter. Use 10 for non-polaxis cases only, as other options are not yet implemented.
     polaxis = 10
     # output_dim define the size of the output image
-    output_dim = 201
-    wavelength = 0.575e-6 # meter, assuming band 1
-    
-    optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':polaxis, 'output_dim':output_dim,\
-                        'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1 }
-    
-    satspot_keywords = {'num_pairs':2, 'sep_lamD': 7, 'angle_deg': [0,90], 'contrast': contrast}
+    output_dim = 101
 
+
+    ## 1) simulate an offset stellar PSF, as a reference ##
+    # calculate offset
+    lam_D = np.degrees(wavelength/2.3)*3600*1000 # in mas
+    shift = [ 1*lam_D,0] # shift in [x,y]
+
+    optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':polaxis, 'output_dim':output_dim,\
+                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1,\
+                 'source_x_offset_mas': shift[0], 'source_y_offset_mas': shift[1]}
+    satspot_keywords = {'num_pairs':2, 'sep_lamD': 6.5, 'angle_deg': [0,90], 'contrast': contrast}
+
+    ##define the corgi.optics class that hold all information about the instrument paramters
     optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)
 
     sim_scene = optics.get_host_star_psf(base_scene)
     image_star = sim_scene.host_star_image.data
-
-
-    optics_with_spots =  instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, satspot_keywords=satspot_keywords, if_quiet=True)                  
-    optics.add_satspot(satspot_keywords)
-
-    sim_scene_with_spots = optics_with_spots.get_host_star_psf(base_scene)
-    image_star_with_spots = sim_scene_with_spots.host_star_image.data
-
-    sim_scene_with_spots_added = optics.get_host_star_psf(base_scene)
-    image_star_with_spots_added = sim_scene_with_spots_added.host_star_image.data
     
-    assert np.all(optics.optics_keywords["dm1_v"] == optics_with_spots.optics_keywords["dm1_v"])
-    assert np.all(image_star_with_spots_added == image_star_with_spots)
+    # Add positive satspots
+    optics.add_satspot(satspot_keywords=satspot_keywords)
+    sim_scene_with_pos_spots = optics.get_host_star_psf(base_scene)
+    image_star_with_pos_spots = sim_scene_with_pos_spots.host_star_image.data
 
-    optics.remove_satspot(satspot_keywords)
-    sim_scene_with_spots_removed = optics.get_host_star_psf(base_scene)
-    image_star_with_spots_removed = sim_scene_with_spots_removed.host_star_image.data
+    # Remove_positive satspots, add negative satspots
+    optics.remove_satspot(satspot_keywords=satspot_keywords)
+    satspot_keywords['sign'] = "negative"
+    optics.add_satspot(satspot_keywords=satspot_keywords)
 
-    assert np.all(image_star_with_spots_removed == image_star)
-    assert np.allclose(optics.optics_keywords["dm1_v"], dm1,rtol=1e-15, atol=1e-15)
+    sim_scene_with_neg_spots = optics.get_host_star_psf(base_scene)
+    image_star_with_neg_spots = sim_scene_with_neg_spots.host_star_image.data
 
+    # Take median image of satellite_spots and remove the star image
+    image_med = np.median(np.stack([image_star_with_pos_spots,image_star_with_neg_spots]), axis = 0)
+
+    image_spots = image_med - image_star
+
+    fov_shape = image_star.shape
+    xcen = (output_dim-1)/2
+    ycen = (output_dim-1)/2
+
+    pix_scale = 0.0218*1000 #mas/pix
+    star_x = xcen+shift[0]/pix_scale
+    star_y = ycen+shift[1]/pix_scale
+
+    fitresult=[]
+    for angle in satspot_keywords['angle_deg']: # note: this line does not work if angle_deg is not list
+        sep = satspot_keywords['sep_lamD']*lam_D # mas
+
+        guess_x1 = star_x+sep*np.cos(np.radians(angle))/pix_scale
+        guess_x2 = star_x-sep*np.cos(np.radians(angle))/pix_scale
+
+        guess_y1 = star_y+sep*np.sin(np.radians(angle))/pix_scale
+        guess_y2 = star_y-sep*np.sin(np.radians(angle))/pix_scale
+
+        for guess_x,guess_y in zip([guess_x1,guess_x2],[guess_y1,guess_y2]):
+            peak,fwhm,x,y=gaussfit2d(image_spots,guess_x,guess_y)
+            fitresult.append([peak,fwhm,x,y])
+
+    #### check location, averaged coordinates the four satellite spots are located at the FoV center
+    guessx_star = np.mean(np.array(fitresult)[:,2])
+    guessy_star = np.mean(np.array(fitresult)[:,3])
+    assert np.sqrt((guessx_star-star_x)**2+(guessy_star-star_y)**2) < 0.5
 
 
 if __name__ == '__main__':
     test_add_satellite_spots()
-    
+    test_add_remove_satellite_spots()
+    test_measure_offset()


### PR DESCRIPTION
## Describe your changes and reference any relevant issues (don't forget the #)
Issue #247 :  satellite spots are put in using the bandpass that has been chosen for the optics (or raise a warning)
Also adds the option to add and remove satellite spots to an already existing objects
Also adds test to ensure that a shift introduced in the optics is present in the final image
 
## Checklist before requesting a review
- [x] I have verified that test_minimal.py passes and I have added a test there if appropriate.

## Checklist before merging
- [x] I have checked the complete tests pass on that branch (check the Github Actions tab)
