### PR TITLE
add gain_CIC_Q

### DIFF
--- a/corgisim/instrument.py
+++ b/corgisim/instrument.py
@@ -1658,6 +1658,7 @@ class CorgiDetector():
             for em_gain > 200 if the number of incoming particles to the gain register is n > 1.  If 'auto', both speed and accuracy are prioritized:the fast method is used 
             if em_gain > 200 (and n>1) and 'roman' is used for gain_CIC_Q,and the slow method is used with gain_CIC_Q = 0 (since partial CIC is negligible for low gains) 
             for em_gain <= 200 (or if n=1 for any gain). Defaults to 'auto'.
+            - gain_CIC_Q: optional: The gain of the CIC (Clock-Induced Charge) in the EM register. Set gain_CIC_Q = 0 to disable it to have faster simulation. The value will be overwrite if fast_gain_mode = 'auto'. 
         Returns:
             - emccd (EMCCDDetectBase): A configured EMCCD detector object. If `use_traps` is True, the detector's CTI is updated using the corresponding trap model.
         
@@ -1683,14 +1684,19 @@ class CorgiDetector():
                                   'row_read_time': 223.5e-6,              # in seconds (needed to simulate smearing)
                                   'nonlin_path': None,                  # path to file containing non-linearity map; if None, no input nonlinearity used
                                   'flat_path': None,            # path to file containing flat field map; if None, no flat field correction used
-                                  'fast_gain_mode':'auto'}
+                                  'fast_gain_mode':'auto',
+                                  'gain_CIC_Q':'Roman'}                 # gain of the CIC in the EM register; set to 0 to disable it to have faster simulation}
         if emccd_keywords is not None:                    
             if 'qe' in emccd_keywords.keys():
                 raise Warning("Quantum efficiency has been added in the bandpass throughput; it must be enforced as 1 here.")
+            
             # Override default parameters with user-specified ones
             for key, value in emccd_keywords.items():
                 if key in self.emccd_keywords_default:
                     self.emccd_keywords_default[key] = value
+
+            if 'gain_CIC_Q' in emccd_keywords and self.emccd_keywords_default.get('fast_gain_mode') == 'auto':
+                warnings.warn("gain_CIC_Q is set by default when fast_gain_mode='auto'. If you want to change gain_CIC_Q, please set fast_gain_mode to True or False.")
 
         if (self.emccd_keywords_default['fast_gain_mode'] and self.emccd_keywords_default['em_gain'] < 200):
             warnings.warn('Warning: Fast gain mode needs em_gain to be over 200 to be reasonably accurate')
@@ -1699,7 +1705,7 @@ class CorgiDetector():
                              dark_current=self.emccd_keywords_default['dark_rate'], cic=self.emccd_keywords_default['cic_noise'], read_noise=self.emccd_keywords_default['read_noise'], bias=self.emccd_keywords_default['bias'],
                              qe=1.0, cr_rate=self.emccd_keywords_default['cr_rate'], pixel_pitch=self.emccd_keywords_default['pixel_pitch'], eperdn=self.emccd_keywords_default['e_per_dn'],
                              numel_gain_register=self.emccd_keywords_default['numel_gain_register'], nbits=self.emccd_keywords_default['nbits'], row_read_time=self.emccd_keywords_default['row_read_time'], 
-                             nonlin_path=self.emccd_keywords_default['nonlin_path'], flat_path=self.emccd_keywords_default['flat_path'])
+                             nonlin_path=self.emccd_keywords_default['nonlin_path'], flat_path=self.emccd_keywords_default['flat_path'], fast_gain_mode=self.emccd_keywords_default['fast_gain_mode'], gain_CIC_Q=self.emccd_keywords_default['gain_CIC_Q'])
         
         if self.emccd_keywords_default['use_traps']: 
             raise ValueError(f"The part to simulate CTI effects using trap models has not been implemented yet!")

--- a/examples/tutorial1_corgisim.ipynb
+++ b/examples/tutorial1_corgisim.ipynb
@@ -700,7 +700,8 @@
     "- **nbits**: Number of bits in the ADC (analog-to-digital converter). Default: `14`.\n",
     "- **use_traps**: Whether to simulate CTI effects using trap models. Default: `False`.\n",
     "- **date4traps**: Decimal year of observation. Only used if `use_traps=True`. Default: `2028.0`.\n",
-    "- **fast_gain_mode** bool or 'auto' If True, a faster but less accurate method (uses Erlang/Gamma distribution for EM gain) of simulating the gain register is used. If 'auto', both speed and accuracy are prioritized. Default to 'auto'\n"
+    "- **fast_gain_mode** bool or 'auto' If True, a faster but less accurate method (uses Erlang/Gamma distribution for EM gain) of simulating the gain register is used. If 'auto', both speed and accuracy are prioritized. Default to 'auto'\n",
+    "- **gain_CIC_Q** optional: The gain of the CIC (Clock-Induced Charge) in the EM register. Set gain_CIC_Q = 0 to disable it to have faster simulation. The value will be overwrite if fast_gain_mode = 'auto'. \n"
    ]
   },
   {
@@ -910,7 +911,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".envCorgisim",
+   "display_name": "CGISim",
    "language": "python",
    "name": "python3"
   },
@@ -924,7 +925,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/test/test_fastgain_parameter.py
+++ b/test/test_fastgain_parameter.py
@@ -1,0 +1,152 @@
+import corgisim
+from corgisim import scene, instrument, outputs, inputs, observation
+from corgisim import instrument
+from astropy.io import fits
+import matplotlib.pyplot as plt
+import numpy as np
+import proper
+import roman_preflight_proper
+import pytest
+import cgisim
+import os, shutil
+import glob
+
+
+def test_fastgain_params():
+    #### testing the defalut value pass to header
+    Vmag = 8
+    sptype = 'G0V'
+    cgi_mode = 'excam'
+    bandpass = '1F'
+    cor_type = 'hlc_band1'
+    
+    info_dir = cgisim.lib_dir + '/cgisim_info_dir/'
+
+    #Define the host star properties
+    host_star_properties = {'Vmag': Vmag, 'spectral_type': sptype, 'magtype': 'vegamag'}
+
+    #Create a Scene object that holds all this information
+    base_scene = scene.Scene(host_star_properties)
+
+    ####setup the wavelength for the simulation, nlam=1 for monochromatic image, nlam>1 for broadband image 
+    cases = ['3e-8']       
+    rootname = 'hlc_ni_' + cases[0]
+    dm1 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm1_v.fits' )
+    dm2 = proper.prop_fits_read( roman_preflight_proper.lib_dir + '/examples/'+rootname+'_dm2_v.fits' )
+
+    optics_keywords ={'cor_type':cor_type, 'use_errors':1, 'polaxis':10, 'output_dim':51,\
+                    'use_dm1':1, 'dm1_v':dm1, 'use_dm2':1, 'dm2_v':dm2,'use_fpm':1, 'use_lyot_stop':1,  'use_field_stop':1, }
+                
+
+    optics = instrument.CorgiOptics(cgi_mode, bandpass, optics_keywords=optics_keywords, if_quiet=True)
+    sim_scene = optics.get_host_star_psf(base_scene)
+    #############################################################################################################
+    emccd_keywords ={'em_gain':1000}
+    exptime = 3000
+ 
+    detector = instrument.CorgiDetector( emccd_keywords)
+    
+    ## defult value of fast_gain_mode is auto
+    ## for em_gain>200, fast_gain_mode is True and gain_CIC_roman is 'Roman'
+    assert detector.emccd.fast_gain_mode == True, f"Expected FAST_GAIN_MODE='True', but got {detector.emccd.fast_gain_mode}"
+    assert detector.emccd.gain_CIC_Q == pytest.approx(detector.emccd.avg_gain_P/40, rel=0.05)
+    print(detector.emccd.fast_gain_mode, detector.emccd.gain_CIC_Q)
+
+    #############################################################################################################
+    emccd_keywords ={'em_gain':100}
+    exptime = 3000
+
+    detector = instrument.CorgiDetector( emccd_keywords)
+    
+    ## defult value of fast_gain_mode is auto
+    ## for em_gain<200, fast_gain_mode is False and gain_CIC_roman is '0'
+    assert detector.emccd.fast_gain_mode == False, f"Expected FAST_GAIN_MODE='False', but got {detector.emccd.fast_gain_mode}"
+    assert detector.emccd.gain_CIC_Q == 0, f"Expected gain_CIC_Q='0', but got {detector.emccd.gain_CIC_Q}"
+
+
+    #############################################################################################################
+
+    emccd_keywords ={'em_gain':1000, 'gain_CIC_Q':0}
+    exptime = 3000
+    
+    with pytest.warns(UserWarning, match='gain_CIC_Q is set by default'):
+        detector = instrument.CorgiDetector(emccd_keywords)
+    
+    ## defult value of fast_gain_mode is auto
+    ## for em_gain>200, fast_gain_mode is True and gain_CIC_roman is 'Roman'
+    ## the input 'gain_CIC_Q':0 will be overwrite if fast_gain_mode is Auto
+    assert detector.emccd.fast_gain_mode == True, f"Expected FAST_GAIN_MODE='True', but got {detector.emccd.fast_gain_mode}"
+    assert detector.emccd.gain_CIC_Q == pytest.approx(detector.emccd.avg_gain_P/40, rel=0.05)
+    
+    
+    
+    #############################################################################################################
+    emccd_keywords ={'em_gain':100, 'gain_CIC_Q':0}
+    exptime = 3000
+
+    with pytest.warns(UserWarning, match='gain_CIC_Q is set by default'):
+        detector = instrument.CorgiDetector(emccd_keywords)
+
+    ## defult value of fast_gain_mode is auto
+    ## for em_gain<200, fast_gain_mode is False and gain_CIC_roman is '0'
+    ## the input 'gain_CIC_Q':0 will be overwrite if fast_gain_mode is Auto
+    assert detector.emccd.fast_gain_mode == False, f"Expected FAST_GAIN_MODE='False', but got {detector.emccd.fast_gain_mode}"
+    assert detector.emccd.gain_CIC_Q == 0, f"Expected gain_CIC_Q='0', but got {detector.emccd.gain_CIC_Q}"
+    
+
+    #############################################################################################################
+
+    emccd_keywords ={'em_gain':1000, 'fast_gain_mode':True, 'gain_CIC_Q':0}
+    exptime = 3000
+
+    detector = instrument.CorgiDetector( emccd_keywords)
+    
+    ##test the emccd_keywords passed to emccd_detect
+
+    ## when fast_gain_mode is not auto, gain_CIC_Q got from  emccd_keywords 
+    assert detector.emccd.fast_gain_mode == True, f"Expected FAST_GAIN_MODE='True', but got {detector.emccd.fast_gain_mode}"
+    assert detector.emccd.gain_CIC_Q == 0, f"Expected gain_CIC_Q='0', but got {detector.emccd.gain_CIC_Q}"
+ 
+    
+    
+    #############################################################################################################
+    emccd_keywords ={'em_gain':100, 'fast_gain_mode':True,'gain_CIC_Q':'roman'}
+    exptime = 3000
+
+    detector = instrument.CorgiDetector( emccd_keywords)
+
+    ## when fast_gain_mode is not auto, gain_CIC_Q got from  emccd_keywords 
+    assert detector.emccd.fast_gain_mode == True, f"Expected FAST_GAIN_MODE='True', but got {detector.emccd.fast_gain_mode}"
+    assert detector.emccd.gain_CIC_Q == pytest.approx(detector.emccd.avg_gain_P/40, rel=0.05)
+
+    #############################################################################################################
+
+    emccd_keywords ={'em_gain':1000, 'fast_gain_mode':False, 'gain_CIC_Q':0}
+    exptime = 3000
+
+    detector = instrument.CorgiDetector( emccd_keywords)
+    
+    ##test the emccd_keywords passed to emccd_detect
+
+    ## when fast_gain_mode is not auto, gain_CIC_Q got from  emccd_keywords 
+    assert detector.emccd.fast_gain_mode == False, f"Expected FAST_GAIN_MODE='False', but got {detector.emccd.fast_gain_mode}"
+    assert detector.emccd.gain_CIC_Q == 0, f"Expected gain_CIC_Q='0', but got {detector.emccd.gain_CIC_Q}"
+ 
+    
+    
+    #############################################################################################################
+    emccd_keywords ={'em_gain':100, 'fast_gain_mode':False,'gain_CIC_Q':'roman'}
+    exptime = 3000
+
+    detector = instrument.CorgiDetector( emccd_keywords)
+
+    ## when fast_gain_mode is not auto, gain_CIC_Q got from  emccd_keywords 
+    assert detector.emccd.fast_gain_mode == False, f"Expected FAST_GAIN_MODE='False', but got {detector.emccd.fast_gain_mode}"
+    assert detector.emccd.gain_CIC_Q == pytest.approx(detector.emccd.avg_gain_P/40, rel=0.05)
+    
+    
+
+    
+
+if __name__ == '__main__':
+    test_fastgain_params()


### PR DESCRIPTION
## Describe your changes and reference any relevant issues (don't forget the #)

Added the gain_CIC_Q keyword to the emccd_keywords dictionary passed to CorgiDetector. Valid values are "roman" or 0; setting it to 0 disables gain-register CIC and can make simulations much faster. If fast_gain_mode == "auto", the input gain_CIC_Q value is overwritten by the default behavior. To set gain_CIC_Q manually, fast_gain_mode must be set to either True or False.


## Checklist before requesting a review
- [ ] I have verified that test_minimal.py passes and I have added a test there if appropriate.

## Checklist before merging
- [ ] I have checked the complete tests pass on that branch (check the Github Actions tab)
